### PR TITLE
Add ResetAll() in topicaliases to prevent error on reconnection

### DIFF
--- a/paho/extensions/topicaliases/topicliases.go
+++ b/paho/extensions/topicaliases/topicliases.go
@@ -79,6 +79,16 @@ func (t *TAHandler) ResetAlias(topic string, a uint16) {
 	t.aliases[a] = topic
 }
 
+// ResetAll resets all alias value.
+// Since topic aliases are not carried over upon reconnection,
+// ResetAll should be called during connection
+func (t *TAHandler) ResetAll() {
+	t.Lock()
+	defer t.Unlock()
+
+	clear(t.aliases)
+}
+
 // PublishHook is designed to be given to an MQTT client and will be executed
 // before a publish is sent allowing it to modify the Properties of the packet.
 // In this case it allows the Topic Alias Handler to automatically replace topic


### PR DESCRIPTION
Related: #271 and #276

This PR introduce `ResetAll` method in `TAHandler`. ResetAll should be called before reconnect. If not, topic alias is used after reconnect, and causes Protocol Error.

Here is a minimal sample code to use `TAHandler` with `autopaho`.

```go
	maxTopicAlias := uint16(100)
	ta := topicaliases.NewTAHandler(maxTopicAlias)

	cliCfg := autopaho.ClientConfig{
		ServerUrls:                    []*url.URL{u},
		CleanStartOnInitialConnection: false,
		OnConnectionUp: func(cm *autopaho.ConnectionManager, connAck *paho.Connack) {
			ta.ResetAll()
		},
		ConnectPacketBuilder: func(c *paho.Connect, u *url.URL) (*paho.Connect, error) {
			c.Properties = &paho.ConnectProperties{
				TopicAliasMaximum: &maxTopicAlias,
			}
			return c, nil
		},
		ClientConfig: paho.ClientConfig{
			PublishHook: ta.PublishHook,
		},
	}
```