### PR TITLE
feat: add context support to router

### DIFF
--- a/autopaho/examples/rpc/main.go
+++ b/autopaho/examples/rpc/main.go
@@ -185,7 +185,7 @@ func main() {
 	router := paho.NewStandardRouter()
 	cliCfg.OnPublishReceived = []func(paho.PublishReceived) (bool, error){
 		func(p paho.PublishReceived) (bool, error) {
-			router.Route(p.Packet.Packet())
+			router.Route(context.TODO(), p.Packet.Packet())
 			return false, nil
 		}}
 

--- a/autopaho/extensions/rpc/rpc.go
+++ b/autopaho/extensions/rpc/rpc.go
@@ -107,7 +107,7 @@ func (h *Handler) Request(ctx context.Context, pb *paho.Publish) (resp *paho.Pub
 	}
 }
 
-func (h *Handler) responseHandler(pb *paho.Publish) {
+func (h *Handler) responseHandler(ctx context.Context, pb *paho.Publish) {
 	if pb.Properties == nil || pb.Properties.CorrelationData == nil {
 		return
 	}


### PR DESCRIPTION
- Add context parameter to Router.Route method
- Add context parameter to router handlers
- Update documentation and examples
- Add context propagation tests

This change allows proper context handling in message routing, enabling timeout control and value propagation through the message handling chain.