### PR TITLE
Ping when no packets received within keep alive period

### DIFF
--- a/autopaho/auto_test.go
+++ b/autopaho/auto_test.go
@@ -38,10 +38,12 @@ import (
 
 const shortDelay = 500 * time.Millisecond // Used when something should happen pretty quickly (increase when debugging)
 const longerDelay = time.Second           // Longer delay than above (for things like test wide context timeout)
+const longestDelay = 5 * longerDelay      // Used when queuing a lot of messages (extra time needed, especially when race detector active)
 
 // When debugging uncomment the below (to prevent tests terminating too quickly)
 // const shortDelay = time.Hour
 // const longerDelay = time.Hour
+// const longestDelay = time.Hour
 
 const dummyURL = "tcp://127.0.0.1:1883"
 

--- a/autopaho/queue_test.go
+++ b/autopaho/queue_test.go
@@ -141,7 +141,7 @@ func TestQueuedMessages(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), longerDelay)
+	ctx, cancel := context.WithTimeout(context.Background(), longestDelay)
 	defer cancel()
 	cm, err := NewConnection(ctx, config)
 	if err != nil {
@@ -204,8 +204,8 @@ func TestQueuedMessages(t *testing.T) {
 	// Wait for all messages to be received
 	select {
 	case <-got200Messages:
-	case <-time.After(5 * longerDelay):
-		t.Fatal("timeout awaiting messages")
+	case <-time.After(longestDelay):
+		t.Fatalf("%s: timeout awaiting messages (got %d) ", time.Now(), len(receivedPublish)) // this is a data race but delay should prevent issues
 	}
 
 	// Disconnect

--- a/paho/client.go
+++ b/paho/client.go
@@ -494,6 +494,7 @@ func (c *Client) incoming(ctx context.Context) {
 				go c.error(err)
 				return
 			}
+			c.config.PingHandler.PacketReceived()
 			switch recv.Type {
 			case packets.CONNACK:
 				c.debug.Println("received CONNACK (unexpected)")


### PR DESCRIPTION
If a client regularly sends packets (e.g. publishes) then it's quite possible that a keepalive would never be sent. This may become an issue with a half open connection because TCP timeouts can take a long time to be detected. With this PR a keepalive will be sent if a packet has not been both sent AND received within the keepalive period. This will mean more network traffic for users who are just sending at QOS0 but should not have a significant impact on other users (and the improvement in reliability seems worth the cost).

Also improve reliability of tests.

Issue #288