### PR TITLE
Prevent blocking in responseHandler() after context cancel

### DIFF
--- a/autopaho/extensions/rpc/rpc.go
+++ b/autopaho/extensions/rpc/rpc.go
@@ -101,6 +101,7 @@ func (h *Handler) Request(ctx context.Context, pb *paho.Publish) (resp *paho.Pub
 
 	select {
 	case <-ctx.Done():
+		_ = h.getCorrelIDChan(string(pb.Properties.CorrelationData))
 		return nil, fmt.Errorf("context ended")
 	case resp = <-rChan:
 		return resp, nil
@@ -117,5 +118,10 @@ func (h *Handler) responseHandler(pb *paho.Publish) {
 		return
 	}
 
-	rChan <- pb
+	select {
+	case rChan <- pb:
+		return
+	default:
+		return
+	}
 }


### PR DESCRIPTION
responseHandler() may block forever if the request is answered late and the context has already been canceled.

closes #289 
