### PR TITLE
use ctx.Err() instead of a new "context ended" error

### DIFF
--- a/autopaho/extensions/rpc/rpc.go
+++ b/autopaho/extensions/rpc/rpc.go
@@ -102,7 +102,7 @@ func (h *Handler) Request(ctx context.Context, pb *paho.Publish) (resp *paho.Pub
 	select {
 	case <-ctx.Done():
 		_ = h.getCorrelIDChan(string(pb.Properties.CorrelationData))
-		return nil, fmt.Errorf("context ended")
+		return nil, ctx.Err()
 	case resp = <-rChan:
 		return resp, nil
 	}


### PR DESCRIPTION
when the context ends `autopaho` rpc handler returns `fmt.Errorf("context ended")` instead of the more usually expected `ctx.Err()` value.

the corresponding implementation in `paho` already correctly returns `ctx.Err()` in such cases