### PR TITLE
Filestore should attempt to create folder if it does not exist

### DIFF
--- a/paho/store/file/store.go
+++ b/paho/store/file/store.go
@@ -46,8 +46,9 @@ func New(path string, prefix string, extension string) (*Store, error) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
 			folderExists = false
+		} else {
+			return nil, fmt.Errorf("stat on folder failed: %w", err)
 		}
-		return nil, fmt.Errorf("stat on folder failed: %w", err)
 	}
 	if !folderExists {
 		if err := os.MkdirAll(path, folderPermissions); err != nil {


### PR DESCRIPTION
Logic bug meant an error was returned in the event `Stat` returned `os.IsNotExist`
If that happened the intent was to try to create the folder but that is not what was happening.