### PR TITLE
Fix OnServerDisconnect not being called when packet has no properties

### DIFF
--- a/packets/disconnect.go
+++ b/packets/disconnect.go
@@ -68,9 +68,14 @@ const (
 // Unpack is the implementation of the interface required function for a packet
 func (d *Disconnect) Unpack(r *bytes.Buffer) error {
 	var err error
+	noProps := r.Len() == 1
 	d.ReasonCode, err = r.ReadByte()
 	if err != nil {
 		return err
+	}
+
+	if noProps {
+		return nil
 	}
 
 	err = d.Properties.Unpack(r, DISCONNECT)


### PR DESCRIPTION
The issue would occur if the broker does not insert a zero for the properties length.

Please provide enough information so that others can review your pull request:

**Testing**

Tested against a mosquitto plugin that kicks clients. This sends the client a packet with the fixed header, a message len of 1, and a reason code, but no props length (allowed by MQTT v5 spec). Validated that with changes, OnServerDisconnect is called.
Added a test to replicate this scenario.

**Closing issues**

closes #302 
