### PR TITLE
Fix AuthResponse success value being set to true on error

### DIFF
--- a/paho/cp_auth.go
+++ b/paho/cp_auth.go
@@ -97,7 +97,7 @@ func AuthResponseFromPacketAuth(a *packets.Auth) *AuthResponse {
 // returns a paho library AuthResponse
 func AuthResponseFromPacketDisconnect(d *packets.Disconnect) *AuthResponse {
 	return &AuthResponse{
-		Success:    true,
+		Success:    false,
 		ReasonCode: d.ReasonCode,
 		Properties: &AuthProperties{
 			ReasonString: d.Properties.ReasonString,


### PR DESCRIPTION
The Success field is set to true even when the server denies your AUTH packet. Simply set this to false when a DISCONNECT response is received.

**Testing**

Added unit test that covers the scenario.

**Closing issues**

closes #314 