### PR TITLE
synctest - improve test speed and reliability

### DIFF
--- a/autopaho/auto_test.go
+++ b/autopaho/auto_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/eclipse/paho.golang/internal/testserver"
@@ -168,114 +169,117 @@ func TestDisconnect(t *testing.T) {
 // TestReconnect confirms that the connection is automatically re-established when lost
 func TestReconnect(t *testing.T) {
 	t.Parallel()
-	server, _ := url.Parse(dummyURL)
-	serverLogger := paholog.NewTestLogger(t, "testServer:")
-	logger := paholog.NewTestLogger(t, "test:")
+	// synctest significantly reduces the tests runtime
+	synctest.Test(t, func(t *testing.T) {
+		server, _ := url.Parse(dummyURL)
+		serverLogger := paholog.NewTestLogger(t, "testServer:")
+		logger := paholog.NewTestLogger(t, "test:")
 
-	ts := testserver.New(serverLogger)
+		ts := testserver.New(serverLogger)
 
-	type tsConnUpMsg struct {
-		cancelFn func()        // Function to cancel test server context
-		done     chan struct{} // Will be closed when the test server has disconnected (and shutdown)
-	}
-	tsConnUpChan := make(chan tsConnUpMsg, 1) // Message will be sent when test server connection is up (buffered so we can detect unexpected attempts)
-	pahoConnUpChan := make(chan struct{}, 1)  // When autopaho reports connection is up write to channel will occur
+		type tsConnUpMsg struct {
+			cancelFn func()        // Function to cancel test server context
+			done     chan struct{} // Will be closed when the test server has disconnected (and shutdown)
+		}
+		tsConnUpChan := make(chan tsConnUpMsg, 1) // Message will be sent when test server connection is up (buffered so we can detect unexpected attempts)
+		pahoConnUpChan := make(chan struct{}, 1)  // When autopaho reports connection is up write to channel will occur
 
-	atCount := 0
+		atCount := 0
 
-	// If we don't set the pinger, paho will recreate it each time; to confirm issue #277 does not reoccur we set it
-	pinger := paho.NewDefaultPinger()
-	pinger.SetDebug(paholog.NewTestLogger(t, "pinger:"))
+		// If we don't set the pinger, paho will recreate it each time; to confirm issue #277 does not reoccur we set it
+		pinger := paho.NewDefaultPinger()
+		pinger.SetDebug(paholog.NewTestLogger(t, "pinger:"))
 
-	config := ClientConfig{
-		ServerUrls:       []*url.URL{server},
-		KeepAlive:        60,
-		ReconnectBackoff: NewConstantBackoff(time.Millisecond), // Retry connection very quickly!
-		ConnectTimeout:   shortDelay,                           // Connection should come up very quickly
-		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
-			atCount += 1
-			if atCount == 2 { // fail on the initial reconnection attempt to exercise retry functionality
-				return nil, errors.New("connection attempt failed")
-			}
-			ctx, cancel := context.WithCancel(ctx)
-			conn, done, err := ts.Connect(ctx)
-			if err == nil { // The above may fail if attempted too quickly (before disconnect processed)
-				tsConnUpChan <- tsConnUpMsg{cancelFn: cancel, done: done}
-			} else {
-				cancel()
-			}
-			return conn, err
-		},
-		OnConnectionUp: func(*ConnectionManager, *paho.Connack) { pahoConnUpChan <- struct{}{} },
-		Debug:          logger,
-		PahoDebug:      logger,
-		PahoErrors:     logger,
-		ClientConfig: paho.ClientConfig{
-			ClientID:    "test",
-			PingHandler: pinger,
-		},
-	}
+		config := ClientConfig{
+			ServerUrls:       []*url.URL{server},
+			KeepAlive:        60,
+			ReconnectBackoff: NewConstantBackoff(time.Millisecond), // Retry connection very quickly!
+			ConnectTimeout:   shortDelay,                           // Connection should come up very quickly
+			AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
+				atCount += 1
+				if atCount == 2 { // fail on the initial reconnection attempt to exercise retry functionality
+					return nil, errors.New("connection attempt failed")
+				}
+				ctx, cancel := context.WithCancel(ctx)
+				conn, done, err := ts.Connect(ctx)
+				if err == nil { // The above may fail if attempted too quickly (before disconnect processed)
+					tsConnUpChan <- tsConnUpMsg{cancelFn: cancel, done: done}
+				} else {
+					cancel()
+				}
+				return conn, err
+			},
+			OnConnectionUp: func(*ConnectionManager, *paho.Connack) { pahoConnUpChan <- struct{}{} },
+			Debug:          logger,
+			PahoDebug:      logger,
+			PahoErrors:     logger,
+			ClientConfig: paho.ClientConfig{
+				ClientID:    "test",
+				PingHandler: pinger,
+			},
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cm, err := NewConnection(ctx, config)
-	if err != nil {
-		t.Fatalf("expected NewConnection success: %s", err)
-	}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		cm, err := NewConnection(ctx, config)
+		if err != nil {
+			t.Fatalf("expected NewConnection success: %s", err)
+		}
 
-	var initialConnUpMsg tsConnUpMsg
-	select {
-	case initialConnUpMsg = <-tsConnUpChan:
-	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting initial connection request")
-	}
-	select {
-	case <-pahoConnUpChan:
-	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting connection up")
-	}
+		var initialConnUpMsg tsConnUpMsg
+		select {
+		case initialConnUpMsg = <-tsConnUpChan:
+		case <-time.After(shortDelay):
+			t.Fatal("timeout awaiting initial connection request")
+		}
+		select {
+		case <-pahoConnUpChan:
+		case <-time.After(shortDelay):
+			t.Fatal("timeout awaiting connection up")
+		}
 
-	// Force a disconnect
-	initialConnUpMsg.cancelFn()
-	select {
-	case <-initialConnUpMsg.done:
-	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting test server shutdown")
-	}
+		// Force a disconnect
+		initialConnUpMsg.cancelFn()
+		select {
+		case <-initialConnUpMsg.done:
+		case <-time.After(shortDelay):
+			t.Fatal("timeout awaiting test server shutdown")
+		}
 
-	// Await reconnection
-	var secondConnUpMsg tsConnUpMsg
-	select {
-	case secondConnUpMsg = <-tsConnUpChan:
-	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting reconnection request")
-	}
-	select {
-	case <-pahoConnUpChan:
-	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting reconnection up")
-	}
+		// Await reconnection
+		var secondConnUpMsg tsConnUpMsg
+		select {
+		case secondConnUpMsg = <-tsConnUpChan:
+		case <-time.After(shortDelay):
+			t.Fatal("timeout awaiting reconnection request")
+		}
+		select {
+		case <-pahoConnUpChan:
+		case <-time.After(shortDelay):
+			t.Fatal("timeout awaiting reconnection up")
+		}
 
-	// Ensure connection is stable (ref issue #227 where pinger caused connection to drop)
-	select {
-	case <-tsConnUpChan:
-		t.Fatalf("connection should be stable after reconnection")
-	case <-time.After(shortDelay):
-	}
+		// Ensure connection is stable (ref issue #227 where pinger caused connection to drop)
+		select {
+		case <-tsConnUpChan:
+			t.Fatalf("connection should be stable after reconnection")
+		case <-time.After(shortDelay):
+		}
 
-	// Clean shutdown
-	cancel() // Cancelling outer context will cascade
+		// Clean shutdown
+		cancel() // Cancelling outer context will cascade
 
-	select {
-	case <-secondConnUpMsg.done:
-	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting second test server shutdown")
-	}
-	select {
-	case <-cm.Done():
-	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting connection manager shutdown")
-	}
+		select {
+		case <-secondConnUpMsg.done:
+		case <-time.After(shortDelay):
+			t.Fatal("timeout awaiting second test server shutdown")
+		}
+		select {
+		case <-cm.Done():
+		case <-time.After(shortDelay):
+			t.Fatal("timeout awaiting connection manager shutdown")
+		}
+	})
 }
 
 // TestBasicPubSub performs pub/sub operations at each QOS level

--- a/autopaho/queue_test.go
+++ b/autopaho/queue_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/eclipse/paho.golang/autopaho/queue"
@@ -46,208 +47,211 @@ import (
 // disconnects during the process).
 func TestQueuedMessages(t *testing.T) {
 	t.Parallel()
-	server, _ := url.Parse(dummyURL)
-	serverLogger := paholog.NewTestLogger(t, "testServer:")
-	logger := paholog.NewTestLogger(t, "test:")
+	// synctest significantly reduces the tests runtime
+	synctest.Test(t, func(t *testing.T) {
+		server, _ := url.Parse(dummyURL)
+		serverLogger := paholog.NewTestLogger(t, "testServer:")
+		logger := paholog.NewTestLogger(t, "test:")
 
-	ts := testserver.New(serverLogger)
-	got200Messages := make(chan struct{}) // Closed when 200 messages received
-	var receivedPublish []*packets.Publish
-	lastDup := 0 // Position in receivedPublish of the last duplicate we received
+		ts := testserver.New(serverLogger)
+		got200Messages := make(chan struct{}) // Closed when 200 messages received
+		var receivedPublish []*packets.Publish
+		lastDup := 0 // Position in receivedPublish of the last duplicate we received
 
-	ts.SetPacketReceivedCallback(func(cp *packets.ControlPacket) error {
-		pub, ok := cp.Content.(*packets.Publish)
-		if !ok {
-			return nil
-		}
-		if pub.Duplicate { // Ignore duplicates if we have received them previously and they are in order
-			for i, msg := range receivedPublish {
-				if bytes.Compare(msg.Payload, pub.Payload) == 0 {
-					if i >= lastDup {
-						lastDup = i // ignoring i<lastDup means out of order messages will result in out of order receivedPublish
-						return nil
+		ts.SetPacketReceivedCallback(func(cp *packets.ControlPacket) error {
+			pub, ok := cp.Content.(*packets.Publish)
+			if !ok {
+				return nil
+			}
+			if pub.Duplicate { // Ignore duplicates if we have received them previously and they are in order
+				for i, msg := range receivedPublish {
+					if bytes.Compare(msg.Payload, pub.Payload) == 0 {
+						if i >= lastDup {
+							lastDup = i // ignoring i<lastDup means receipt of an out-of-order message will be detected
+							return nil
+						}
 					}
 				}
 			}
-		}
-		receivedPublish = append(receivedPublish, pub)
-		if l := len(receivedPublish); l == 200 {
-			close(got200Messages)
-		} else if l%20 == 0 {
-			return fmt.Errorf("disconnecting every 20 messages") // Test interaction of queue and store
-		}
-		return nil
-	})
-
-	// We expect messages
-	pahoConnUpChan := make(chan struct{}) // Closed first time autopaho reports connection is up
-
-	var allowConnection atomic.Bool
-
-	// Add a corrupt item to the queue (zero bytes) - this should be logged and ignored
-	q := memqueue.New()
-	if err := q.Enqueue(bytes.NewReader(nil)); err != nil {
-		t.Fatalf("failed to add corrupt zero byte item to queue")
-	}
-
-	// custom session because we don't want the client to close it when the connection is lost
-	var tsDone chan struct{} // Set on AttemptConnection and closed when that test server connection is done
-	clientStore := memstore.New()
-	serverStore := memstore.New()
-	session := state.New(clientStore, serverStore)
-	session.SetErrorLogger(paholog.NewTestLogger(t, "sessionError:"))
-	session.SetDebugLogger(paholog.NewTestLogger(t, "sessionDebug:"))
-	defer session.Close()
-
-	// Add a corrupt item to the store (zero bytes) - this should be logged and ignored
-	clientStore.Put(1, packets.PUBLISH, bytes.NewReader(nil))
-	serverStore.Put(1, packets.PUBREC, bytes.NewReader(nil))
-
-	connectCount := 0
-	config := ClientConfig{
-		ServerUrls:       []*url.URL{server},
-		KeepAlive:        60,
-		ReconnectBackoff: NewConstantBackoff(500 * time.Millisecond), // Retry connection very quickly!
-		ConnectTimeout:   shortDelay,                                 // Connection should come up very quickly
-		Queue:            q,
-		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
-			if !allowConnection.Load() {
-				return nil, fmt.Errorf("some random error")
+			receivedPublish = append(receivedPublish, pub)
+			if l := len(receivedPublish); l == 200 {
+				close(got200Messages)
+			} else if l%20 == 0 {
+				return fmt.Errorf("disconnecting every 20 messages") // Test interaction of queue and store
 			}
-			var conn net.Conn
-			var err error
-			conn, tsDone, err = ts.Connect(ctx)
-			return conn, err
-		},
-		OnConnectionUp: func(*ConnectionManager, *paho.Connack) {
-			connectCount++
-			if connectCount == 1 {
-				close(pahoConnUpChan)
-			}
-		},
-		Debug:                         logger,
-		Errors:                        logger,
-		PahoDebug:                     logger,
-		PahoErrors:                    logger,
-		CleanStartOnInitialConnection: false, // Want session to stay up (this is the default)
-		SessionExpiryInterval:         600,   // If 0 then the state will be removed when the connection drops
-		ClientConfig: paho.ClientConfig{
-			ClientID: "test",
-			Session:  session,
-			OnPublishReceived: []func(paho.PublishReceived) (bool, error){ // Noop handler
-				func(pr paho.PublishReceived) (bool, error) {
-					return true, nil
-				}},
-		},
-	}
+			return nil
+		})
 
-	ctx, cancel := context.WithTimeout(context.Background(), longestDelay)
-	defer cancel()
-	cm, err := NewConnection(ctx, config)
-	if err != nil {
-		t.Fatalf("expected NewConnection success: %s", err)
-	}
+		// We expect messages
+		pahoConnUpChan := make(chan struct{}) // Closed first time autopaho reports connection is up
 
-	testFmt := "Test%d"
-	// Start with an invalid message; this will be queued but then rejected by paho.PublishWithOptions, and it's
-	// important that it's discarded (otherwise it would be retried continually) - issue #214
-	if err = cm.PublishViaQueue(ctx, &QueuePublish{
-		Publish: &paho.Publish{
-			QoS:        3,
-			Topic:      fmt.Sprintf(testFmt, 0),
-			Properties: nil,
-			Payload:    []byte(fmt.Sprintf(testFmt, 0)),
-		},
-	}); err != nil {
-		t.Fatalf("invalid publish failed")
-	}
+		var allowConnection atomic.Bool
 
-	// Transmit first 100 messages (should go into queue)
-	for i := 1; i <= 100; i++ {
-		msg := fmt.Sprintf(testFmt, i)
-		if err = cm.PublishViaQueue(ctx, &QueuePublish{
-			Publish: &paho.Publish{
-				QoS:        1,
-				Topic:      msg,
-				Properties: nil,
-				Payload:    []byte(msg),
-			},
-		}); err != nil {
-			t.Fatalf("publish %d failed", i)
+		// Add a corrupt item to the queue (zero bytes) - this should be logged and ignored
+		q := memqueue.New()
+		if err := q.Enqueue(bytes.NewReader(nil)); err != nil {
+			t.Fatalf("failed to add corrupt zero byte item to queue")
 		}
-		time.Sleep(time.Millisecond) // for logging
-	}
 
-	// Allow connection to come up and wait for this to happen
-	allowConnection.Store(true)
-	select {
-	case <-pahoConnUpChan:
-	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting connection up")
-	}
+		// custom session because we don't want the client to close it when the connection is lost
+		var tsDone chan struct{} // Set on AttemptConnection and closed when that test server connection is done
+		clientStore := memstore.New()
+		serverStore := memstore.New()
+		session := state.New(clientStore, serverStore)
+		session.SetErrorLogger(paholog.NewTestLogger(t, "sessionError:"))
+		session.SetDebugLogger(paholog.NewTestLogger(t, "sessionDebug:"))
+		defer session.Close()
 
-	// Transmit another 100 messages
-	for i := 101; i <= 200; i++ {
-		msg := fmt.Sprintf(testFmt, i)
-		if err = cm.PublishViaQueue(ctx, &QueuePublish{
-			Publish: &paho.Publish{
-				QoS:        1,
-				Topic:      msg,
-				Properties: nil,
-				Payload:    []byte(msg),
+		// Add a corrupt item to the store (zero bytes) - this should be logged and ignored
+		clientStore.Put(1, packets.PUBLISH, bytes.NewReader(nil))
+		serverStore.Put(1, packets.PUBREC, bytes.NewReader(nil))
+
+		connectCount := 0
+		config := ClientConfig{
+			ServerUrls:       []*url.URL{server},
+			KeepAlive:        60,
+			ReconnectBackoff: NewConstantBackoff(500 * time.Millisecond), // Retry connection very quickly!
+			ConnectTimeout:   shortDelay,                                 // Connection should come up very quickly
+			Queue:            q,
+			AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
+				if !allowConnection.Load() {
+					return nil, fmt.Errorf("some random error")
+				}
+				var conn net.Conn
+				var err error
+				conn, tsDone, err = ts.Connect(ctx)
+				return conn, err
 			},
-		}); err != nil {
-			t.Fatalf("publish %d failed", i)
+			OnConnectionUp: func(*ConnectionManager, *paho.Connack) {
+				connectCount++
+				if connectCount == 1 {
+					close(pahoConnUpChan)
+				}
+			},
+			Debug:                         logger,
+			Errors:                        logger,
+			PahoDebug:                     logger,
+			PahoErrors:                    logger,
+			CleanStartOnInitialConnection: false, // Want session to stay up (this is the default)
+			SessionExpiryInterval:         600,   // If 0 then the state will be removed when the connection drops
+			ClientConfig: paho.ClientConfig{
+				ClientID: "test",
+				Session:  session,
+				OnPublishReceived: []func(paho.PublishReceived) (bool, error){ // Noop handler
+					func(pr paho.PublishReceived) (bool, error) {
+						return true, nil
+					}},
+			},
 		}
-	}
 
-	// Wait for all messages to be received
-	select {
-	case <-got200Messages:
-	case <-time.After(longestDelay):
-		t.Fatalf("%s: timeout awaiting messages (got %d) ", time.Now(), len(receivedPublish)) // this is a data race but delay should prevent issues
-	}
-
-	// Disconnect
-	disconnectErr := make(chan error)
-	go func() {
-		disconnectErr <- cm.Disconnect(ctx)
-	}()
-	select {
-	case err = <-disconnectErr:
+		ctx, cancel := context.WithTimeout(context.Background(), longestDelay)
+		defer cancel()
+		cm, err := NewConnection(ctx, config)
 		if err != nil {
-			t.Fatalf("Disconnect returned error: %s", err)
+			t.Fatalf("expected NewConnection success: %s", err)
 		}
-	case <-time.After(longerDelay):
-		t.Fatal("Disconnect should return relatively quickly")
-	}
 
-	// Connection manager should be Done
-	select {
-	case <-cm.Done():
-	case <-time.After(shortDelay):
-		t.Fatal("connection manager should be done after Disconnect Called")
-	}
-
-	// The test server should have picked up the dropped connection
-	select {
-	case <-tsDone:
-	case <-time.After(shortDelay):
-		t.Fatal("test server did not shutdown within expected time")
-	}
-
-	// Check that the queue is empty
-	if _, err := cm.queue.Peek(); !errors.Is(err, queue.ErrEmpty) {
-		t.Error("queue should be empty")
-	}
-
-	// Check that we received the expected messages, in the expected order
-	for i := 1; i <= 200; i++ {
-		exp := fmt.Sprintf(testFmt, i)
-		if string(receivedPublish[i-1].Payload) != exp {
-			t.Errorf("expected %s, got %s", exp, receivedPublish[i-1])
+		testFmt := "Test%d"
+		// Start with an invalid message; this will be queued but then rejected by paho.PublishWithOptions, and it's
+		// important that it's discarded (otherwise it would be retried continually) - issue #214
+		if err = cm.PublishViaQueue(ctx, &QueuePublish{
+			Publish: &paho.Publish{
+				QoS:        3,
+				Topic:      fmt.Sprintf(testFmt, 0),
+				Properties: nil,
+				Payload:    []byte(fmt.Sprintf(testFmt, 0)),
+			},
+		}); err != nil {
+			t.Fatalf("invalid publish failed")
 		}
-	}
+
+		// Transmit first 100 messages (should go into queue)
+		for i := 1; i <= 100; i++ {
+			msg := fmt.Sprintf(testFmt, i)
+			if err = cm.PublishViaQueue(ctx, &QueuePublish{
+				Publish: &paho.Publish{
+					QoS:        1,
+					Topic:      msg,
+					Properties: nil,
+					Payload:    []byte(msg),
+				},
+			}); err != nil {
+				t.Fatalf("publish %d failed", i)
+			}
+			time.Sleep(time.Millisecond) // for logging
+		}
+
+		// Allow connection to come up and wait for this to happen
+		allowConnection.Store(true)
+		select {
+		case <-pahoConnUpChan:
+		case <-time.After(shortDelay):
+			t.Fatal("timeout awaiting connection up")
+		}
+
+		// Transmit another 100 messages
+		for i := 101; i <= 200; i++ {
+			msg := fmt.Sprintf(testFmt, i)
+			if err = cm.PublishViaQueue(ctx, &QueuePublish{
+				Publish: &paho.Publish{
+					QoS:        1,
+					Topic:      msg,
+					Properties: nil,
+					Payload:    []byte(msg),
+				},
+			}); err != nil {
+				t.Fatalf("publish %d failed", i)
+			}
+		}
+
+		// Wait for all messages to be received
+		select {
+		case <-got200Messages:
+		case <-time.After(longestDelay):
+			t.Fatalf("%s: timeout awaiting messages (got %d) ", time.Now(), len(receivedPublish)) // this is a data race but delay should prevent issues
+		}
+
+		// Disconnect
+		disconnectErr := make(chan error)
+		go func() {
+			disconnectErr <- cm.Disconnect(ctx)
+		}()
+		select {
+		case err = <-disconnectErr:
+			if err != nil {
+				t.Fatalf("Disconnect returned error: %s", err)
+			}
+		case <-time.After(longerDelay):
+			t.Fatal("Disconnect should return relatively quickly")
+		}
+
+		// Connection manager should be Done
+		select {
+		case <-cm.Done():
+		case <-time.After(shortDelay):
+			t.Fatal("connection manager should be done after Disconnect Called")
+		}
+
+		// The test server should have picked up the dropped connection
+		select {
+		case <-tsDone:
+		case <-time.After(shortDelay):
+			t.Fatal("test server did not shutdown within expected time")
+		}
+
+		// Check that the queue is empty
+		if _, err := cm.queue.Peek(); !errors.Is(err, queue.ErrEmpty) {
+			t.Error("queue should be empty")
+		}
+
+		// Check that we received the expected messages, in the expected order
+		for i := 1; i <= 200; i++ {
+			exp := fmt.Sprintf(testFmt, i)
+			if string(receivedPublish[i-1].Payload) != exp {
+				t.Errorf("expected %s, got %s", exp, receivedPublish[i-1])
+			}
+		}
+	})
 }
 
 // TestPreloadPublish begin connection with PUBLISH packets in queue and a slow server
@@ -256,131 +260,134 @@ func TestQueuedMessages(t *testing.T) {
 func TestPreloadPublish(t *testing.T) {
 	t.Parallel()
 
-	// Bring up server
-	server, _ := url.Parse(dummyURL)
-	serverLogger := paholog.NewTestLogger(t, "testServer:")
-	logger := paholog.NewTestLogger(t, "test:")
+	// synctest significantly reduces the tests runtime
+	synctest.Test(t, func(t *testing.T) {
+		// Bring up server
+		server, _ := url.Parse(dummyURL)
+		serverLogger := paholog.NewTestLogger(t, "testServer:")
+		logger := paholog.NewTestLogger(t, "test:")
 
-	ts := testserver.New(serverLogger)
+		ts := testserver.New(serverLogger)
 
-	var publishReceived int32
-	gotMessage := make(map[string]bool)
-	got5Messages := make(chan struct{})
+		var publishReceived int32
+		gotMessage := make(map[string]bool)
+		got5Messages := make(chan struct{})
 
-	ts.SetPacketReceivedCallback(func(cp *packets.ControlPacket) error {
-		if cp.Type != packets.PUBLISH {
-			return nil // Ignore packets other than PUBLISH
-		}
-		pub := cp.Content.(*packets.Publish)
-		gotMessage[pub.Topic] = true
-		if len(gotMessage) == 5 {
-			gotMessage["z"] = true // stop the above from being true if called again
-			close(got5Messages)
-		}
-
-		if publishReceived == 0 { // test server process in one go routine, so this will block all initial PUBLISH requests
-			time.Sleep(shortDelay) // delay ack
-		}
-		publishReceived++
-		return nil
-	})
-	ts.SetConnectCallback(func(cp *packets.Connect, cap *packets.Connack) {
-		rm := uint16(2)
-		cap.Properties.ReceiveMaximum = &rm
-	})
-
-	q := memqueue.New()
-	for i := 0; i < 5; i++ {
-		r, w := io.Pipe()
-
-		go func() {
-			publish := packets.Publish{
-				Topic:   strconv.Itoa(i),
-				Payload: []byte("packet: " + strconv.Itoa(i)),
-				QoS:     1,
+		ts.SetPacketReceivedCallback(func(cp *packets.ControlPacket) error {
+			if cp.Type != packets.PUBLISH {
+				return nil // Ignore packets other than PUBLISH
 			}
-			_, _ = publish.WriteTo(w)
-			w.Close()
-		}()
+			pub := cp.Content.(*packets.Publish)
+			gotMessage[pub.Topic] = true
+			if len(gotMessage) == 5 {
+				gotMessage["z"] = true // stop the above from being true if called again
+				close(got5Messages)
+			}
 
-		if err := q.Enqueue(r); err != nil {
-			t.Fatalf("failed to enqueue: %s", err)
+			if publishReceived == 0 { // test server process in one go routine, so this will block all initial PUBLISH requests
+				time.Sleep(shortDelay) // delay ack
+			}
+			publishReceived++
+			return nil
+		})
+		ts.SetConnectCallback(func(cp *packets.Connect, cap *packets.Connack) {
+			rm := uint16(2)
+			cap.Properties.ReceiveMaximum = &rm
+		})
+
+		q := memqueue.New()
+		for i := 0; i < 5; i++ {
+			r, w := io.Pipe()
+
+			go func() {
+				publish := packets.Publish{
+					Topic:   strconv.Itoa(i),
+					Payload: []byte("packet: " + strconv.Itoa(i)),
+					QoS:     1,
+				}
+				_, _ = publish.WriteTo(w)
+				w.Close()
+			}()
+
+			if err := q.Enqueue(r); err != nil {
+				t.Fatalf("failed to enqueue: %s", err)
+			}
 		}
-	}
 
-	// custom session because we don't want the client to close it when the connection is lost
-	var tsDone chan struct{} // Set on AttemptConnection and closed when that test server connection is done
-	session := state.NewInMemory()
-	session.SetErrorLogger(paholog.NewTestLogger(t, "sessionError:"))
-	session.SetDebugLogger(paholog.NewTestLogger(t, "sessionDebug:"))
-	defer session.Close()
-	config := ClientConfig{
-		ServerUrls:       []*url.URL{server},
-		KeepAlive:        0,
-		ReconnectBackoff: NewConstantBackoff(shortDelay), // Retry connection very quickly!
-		ConnectTimeout:   shortDelay,                     // Connection should come up very quickly
-		Queue:            q,
-		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
-			var conn net.Conn
-			var err error
-			conn, tsDone, err = ts.Connect(ctx)
-			return conn, err
-		},
-		Debug:                         logger,
-		PahoDebug:                     logger,
-		PahoErrors:                    logger,
-		CleanStartOnInitialConnection: false, // Want session to stay up (this is the default)
-		SessionExpiryInterval:         600,   // If 0 then the state will be removed when the connection drops
-		ClientConfig: paho.ClientConfig{
-			ClientID: "test",
-			Session:  session,
-			OnPublishReceived: []func(paho.PublishReceived) (bool, error){ // Noop handler
-				func(pr paho.PublishReceived) (bool, error) {
-					return true, nil
-				}},
-			PacketTimeout: 250 * time.Millisecond, // test server should be able to respond very quickly!
-		},
-	}
+		// custom session because we don't want the client to close it when the connection is lost
+		var tsDone chan struct{} // Set on AttemptConnection and closed when that test server connection is done
+		session := state.NewInMemory()
+		session.SetErrorLogger(paholog.NewTestLogger(t, "sessionError:"))
+		session.SetDebugLogger(paholog.NewTestLogger(t, "sessionDebug:"))
+		defer session.Close()
+		config := ClientConfig{
+			ServerUrls:       []*url.URL{server},
+			KeepAlive:        0,
+			ReconnectBackoff: NewConstantBackoff(shortDelay), // Retry connection very quickly!
+			ConnectTimeout:   shortDelay,                     // Connection should come up very quickly
+			Queue:            q,
+			AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
+				var conn net.Conn
+				var err error
+				conn, tsDone, err = ts.Connect(ctx)
+				return conn, err
+			},
+			Debug:                         logger,
+			PahoDebug:                     logger,
+			PahoErrors:                    logger,
+			CleanStartOnInitialConnection: false, // Want session to stay up (this is the default)
+			SessionExpiryInterval:         600,   // If 0 then the state will be removed when the connection drops
+			ClientConfig: paho.ClientConfig{
+				ClientID: "test",
+				Session:  session,
+				OnPublishReceived: []func(paho.PublishReceived) (bool, error){ // Noop handler
+					func(pr paho.PublishReceived) (bool, error) {
+						return true, nil
+					}},
+				PacketTimeout: 250 * time.Millisecond, // test server should be able to respond very quickly!
+			},
+		}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	cm, err := NewConnection(ctx, config)
-	if err != nil {
-		t.Fatalf("expected NewConnection success: %s", err)
-	}
-
-	// Wait for all messages to be received
-	select {
-	case <-got5Messages:
-	case <-time.After(5 * longerDelay): // Need a bit longer...
-		t.Fatalf("timeout awaiting messages (received %d)", publishReceived)
-	}
-
-	// Disconnect
-	disconnectErr := make(chan error)
-	go func() {
-		disconnectErr <- cm.Disconnect(ctx)
-	}()
-	select {
-	case err = <-disconnectErr:
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		cm, err := NewConnection(ctx, config)
 		if err != nil {
-			t.Fatalf("Disconnect returned error: %s", err)
+			t.Fatalf("expected NewConnection success: %s", err)
 		}
-	case <-time.After(longerDelay):
-		t.Fatal("Disconnect should return relatively quickly")
-	}
 
-	// Connection manager should be Done
-	select {
-	case <-cm.Done():
-	case <-time.After(shortDelay):
-		t.Fatal("connection manager should be done after Disconnect Called")
-	}
+		// Wait for all messages to be received
+		select {
+		case <-got5Messages:
+		case <-time.After(5 * longerDelay): // Need a bit longer...
+			t.Fatalf("timeout awaiting messages (received %d)", publishReceived)
+		}
 
-	// The test server should have picked up the dropped connection
-	select {
-	case <-tsDone:
-	case <-time.After(shortDelay):
-		t.Fatal("test server did not shutdown within expected time")
-	}
+		// Disconnect
+		disconnectErr := make(chan error)
+		go func() {
+			disconnectErr <- cm.Disconnect(ctx)
+		}()
+		select {
+		case err = <-disconnectErr:
+			if err != nil {
+				t.Fatalf("Disconnect returned error: %s", err)
+			}
+		case <-time.After(longerDelay):
+			t.Fatal("Disconnect should return relatively quickly")
+		}
+
+		// Connection manager should be Done
+		select {
+		case <-cm.Done():
+		case <-time.After(shortDelay):
+			t.Fatal("connection manager should be done after Disconnect Called")
+		}
+
+		// The test server should have picked up the dropped connection
+		select {
+		case <-tsDone:
+		case <-time.After(shortDelay):
+			t.Fatal("test server did not shutdown within expected time")
+		}
+	})
 }

--- a/internal/testserver/buffered_conn.go
+++ b/internal/testserver/buffered_conn.go
@@ -1,0 +1,446 @@
+// Code from https://github.com/golang/go/blob/master/src/internal/nettest/conn.go
+// (hopefully this will be made available for import in a future Go release)
+// Provides support for a fake network connection. The existing net.Pipe is synchronous which can lead to unexpected,
+// and challenging to debug, test failures.
+// License: https://github.com/golang/go/blob/master/LICENSE
+// https://www.eclipse.org/legal/eca/ "The contribution is based upon previous work that, to the best of my knowledge,
+//                                     is covered under an appropriate open source license...".
+// Last copied from Go Source: 2026-05-31 (only moodification is to change the package name)
+//
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testserver
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math"
+	"net"
+	"net/netip"
+	"os"
+	"time"
+)
+
+// Conn is an in-memory test implementation of net.Conn.
+type Conn struct {
+	// Conns come in pairs.
+	// Writes to one Conn are read by its peer, and vice-versa.
+	//
+	// A connHalf handles one direction of data flow.
+	// A Conn consists of read and write halves.
+	// A Conn's peer has the same halves, only swapped.
+	//
+	// A Conn reads from r and writes to w.
+	r, w *connHalf
+
+	// peer is the other endpoint.
+	peer *Conn
+}
+
+// NewConnPair returns a pair of connected Conns.
+func NewConnPair() (*Conn, *Conn) {
+	return newConnPair(
+		net.TCPAddrFromAddrPort(netip.MustParseAddrPort("127.0.0.1:10000")),
+		net.TCPAddrFromAddrPort(netip.MustParseAddrPort("127.0.0.1:10001")),
+	)
+}
+
+func newConnPair(addr1, addr2 net.Addr) (*Conn, *Conn) {
+	h1 := newConnHalf(addr1)
+	h2 := newConnHalf(addr2)
+	c1 := &Conn{r: h1, w: h2}
+	c2 := &Conn{r: h2, w: h1}
+	c1.peer = c2
+	c2.peer = c1
+	c1.SetReadBufferSize(-1)
+	c2.SetReadBufferSize(-1)
+	return c1, c2
+}
+
+// Peer returns the other end of the connection.
+func (c *Conn) Peer() *Conn {
+	return c.peer
+}
+
+// Read reads data from the connection.
+func (c *Conn) Read(b []byte) (n int, err error) {
+	n, err = c.r.read(b)
+	if err != nil && err != io.EOF {
+		err = &net.OpError{
+			Op:     "read",
+			Net:    "tcp",
+			Source: c.RemoteAddr(),
+			Addr:   c.LocalAddr(),
+			Err:    err,
+		}
+	}
+	return n, err
+}
+
+// CanRead reports whether Read can proceed without blocking.
+func (c *Conn) CanRead() bool {
+	return c.r.canRead()
+}
+
+// Write writes data to the connection.
+func (c *Conn) Write(b []byte) (n int, err error) {
+	n, err = c.w.write(b)
+	if err != nil {
+		err = &net.OpError{
+			Op:     "write",
+			Net:    "tcp",
+			Source: c.LocalAddr(),
+			Addr:   c.RemoteAddr(),
+			Err:    err,
+		}
+	}
+	return n, err
+}
+
+// IsClosed reports whether the connection has been closed.
+// A connection is closed if [CloseRead] and [CloseWrite] are both called,
+// or if [Close] is called.
+//
+// To identify when the other side of the Conn has been closed,
+// use Conn.Peer().IsClosed().
+func (c *Conn) IsClosed() bool {
+	c.r.lock()
+	readClosed := c.r.readClosed
+	c.r.unlock()
+	c.w.lock()
+	writeClosed := c.w.writeClosed
+	c.w.unlock()
+	return readClosed && writeClosed
+}
+
+var errClosedByPeer = errors.New("connection closed by peer")
+
+// CloseRead shuts down the reading side of the connection.
+func (c *Conn) CloseRead() error {
+	c.r.lock()
+	defer c.r.unlock()
+	c.r.buf.Reset() // discard unread data
+	c.r.readClosed = true
+	return nil
+}
+
+// CloseWrite shuts down the writing side of the connection.
+func (c *Conn) CloseWrite() error {
+	c.w.lock()
+	defer c.w.unlock()
+	c.w.writeClosed = true
+	return nil
+}
+
+// Close closes the connection.
+func (c *Conn) Close() error {
+	c.r.lock()
+	readClosed := c.r.readClosed
+	c.r.buf.Reset() // discard unread data
+	c.r.readClosed = true
+	err := c.r.closeErr
+	c.r.unlock()
+
+	c.w.lock()
+	writeClosed := c.w.writeClosed
+	c.w.writeClosed = true
+	c.w.unlock()
+
+	if readClosed && writeClosed {
+		err = net.ErrClosed
+	}
+	if err != nil {
+		err = &net.OpError{
+			Op:   "close",
+			Net:  "tcp",
+			Addr: c.LocalAddr(),
+			Err:  err,
+		}
+	}
+	return err
+}
+
+// SetCloseError sets the error returned by Close.
+// Close still closes the connection.
+// A nil error restores the usual behavior.
+func (c *Conn) SetCloseError(err error) {
+	c.r.lock()
+	c.r.closeErr = err
+	c.r.unlock()
+}
+
+// LocalAddr returns the (fake) local network address.
+func (c *Conn) LocalAddr() net.Addr {
+	c.r.lock()
+	defer c.r.unlock()
+	return c.r.addr
+}
+
+// SetLocalAddr sets the local address.
+//
+// To set the remote address, set the local address of Conn's peer.
+func (c *Conn) SetLocalAddr(addr net.Addr) {
+	c.r.lock()
+	defer c.r.unlock()
+	c.r.addr = addr
+}
+
+// LocalAddr returns the (fake) remote network address.
+func (c *Conn) RemoteAddr() net.Addr {
+	c.r.lock()
+	defer c.r.unlock()
+	return c.w.addr
+}
+
+// SetDeadline sets the read and write deadlines for the connection.
+func (c *Conn) SetDeadline(t time.Time) error {
+	c.SetReadDeadline(t)
+	c.SetWriteDeadline(t)
+	return nil
+}
+
+// SetReadDeadline sets the read deadline for the connection.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.r.readDeadline.setDeadline(c.r, t)
+	return nil
+}
+
+// SetWriteDeadline sets the write deadline for the connection.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	c.w.writeDeadline.setDeadline(c.w, t)
+	return nil
+}
+
+// SetReadBufferSize sets the connection's read buffer.
+// Writes to the other end of the connection will block so long as the buffer is full.
+// Setting the size to 0 blocks all writes until the size is increased.
+func (c *Conn) SetReadBufferSize(size int) {
+	if size < 0 {
+		size = math.MaxInt
+	}
+	c.r.setBufferSize(size)
+}
+
+// SetReadError causes any currently blocked and future Read calls to return
+// a net.OpError wrapping err. It does not affect the other half of the connection.
+// Reads will return any buffered data before returning the error,
+// including data written after the error is set and io.EOF after the other end is closed.
+// A nil error restores the usual behavior.
+func (c *Conn) SetReadError(err error) {
+	c.r.lock()
+	defer c.r.unlock()
+	c.r.readErr = err
+}
+
+// SetWriteError causes any currently blocked and future Write calls to return
+// a net.OpError wrapping err. It does not affect the other half of the connection.
+// Writes will not write data to the connection buffer while an error is set.
+// A nil error restores the usual behavior.
+func (c *Conn) SetWriteError(err error) {
+	c.w.lock()
+	defer c.w.unlock()
+	c.w.writeErr = err
+}
+
+// connHalf is one direction data flow in a Conn.
+// The connHalf contains a buffer.
+// Writes to the connHalf push to the buffer and reads pull from it.
+type connHalf struct {
+	addr net.Addr
+
+	// A half can be readable and/or writable.
+	//
+	// These four channels act as a lock,
+	// and allow waiting for readability/writability.
+	// When the half is unlocked, exactly one channel contains a value.
+	// When the half is locked, all channels are empty.
+	lockr  chan struct{} // readable
+	lockw  chan struct{} // writable
+	lockrw chan struct{} // readable and writable
+	lockc  chan struct{} // neither readable nor writable
+
+	// Read and write timeouts.
+	readDeadline, writeDeadline connDeadline
+
+	bufMax int // maximum buffer size
+	buf    bytes.Buffer
+
+	readClosed, writeClosed bool
+	readErr, writeErr       error // errors returned by reads/writes
+	closeErr                error // error returned by closing the conn reading from this half
+}
+
+func newConnHalf(addr net.Addr) *connHalf {
+	h := &connHalf{
+		addr:   addr,
+		lockw:  make(chan struct{}, 1),
+		lockr:  make(chan struct{}, 1),
+		lockrw: make(chan struct{}, 1),
+		lockc:  make(chan struct{}, 1),
+		bufMax: math.MaxInt, // unlimited
+	}
+	h.unlock()
+	return h
+}
+
+// lock locks h.
+func (h *connHalf) lock() {
+	select {
+	case <-h.lockw: // writable
+	case <-h.lockr: // readable
+	case <-h.lockrw: // readable and writable
+	case <-h.lockc: // neither readable nor writable
+	}
+}
+
+// unlock unlocks h.
+func (h *connHalf) unlock() {
+	canRead := h.canReadLocked()
+	canWrite := h.canWriteLocked()
+	switch {
+	case canRead && canWrite:
+		h.lockrw <- struct{}{} // readable and writable
+	case canRead:
+		h.lockr <- struct{}{} // readable
+	case canWrite:
+		h.lockw <- struct{}{} // writable
+	default:
+		h.lockc <- struct{}{} // neither readable nor writable
+	}
+}
+
+func (h *connHalf) canRead() bool {
+	h.lock()
+	defer h.unlock()
+	return h.canReadLocked()
+}
+
+func (h *connHalf) canReadLocked() bool {
+	return h.readErr != nil || h.readDeadline.expired || h.buf.Len() > 0 || h.readClosed || h.writeClosed
+}
+
+func (h *connHalf) canWriteLocked() bool {
+	return h.writeErr != nil || h.writeDeadline.expired || h.bufMax > h.buf.Len() || h.readClosed || h.writeClosed
+}
+
+// waitAndLockForRead waits until h is readable and locks it.
+func (h *connHalf) waitAndLockForRead() {
+	select {
+	case <-h.lockr:
+		// readable
+	case <-h.lockrw:
+		// readable and writable
+	}
+}
+
+// waitAndLockForWrite waits until h is writable and locks it.
+func (h *connHalf) waitAndLockForWrite() {
+	select {
+	case <-h.lockw:
+		// writable
+	case <-h.lockrw:
+		// readable and writable
+	}
+}
+
+func (h *connHalf) read(b []byte) (n int, err error) {
+	h.waitAndLockForRead()
+	defer h.unlock()
+	if h.readClosed {
+		return 0, net.ErrClosed
+	}
+	if h.readDeadline.expired {
+		return 0, os.ErrDeadlineExceeded
+	}
+	if h.buf.Len() > 0 {
+		return h.buf.Read(b)
+	}
+	if h.writeClosed {
+		return 0, io.EOF
+	}
+	return 0, h.readErr
+}
+
+func (h *connHalf) setBufferSize(size int) {
+	h.lock()
+	defer h.unlock()
+	h.bufMax = size
+}
+
+func (h *connHalf) write(b []byte) (n int, err error) {
+	for n < len(b) {
+		nn, err := h.writePartial(b[n:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+func (h *connHalf) writePartial(b []byte) (n int, err error) {
+	h.waitAndLockForWrite()
+	defer h.unlock()
+	if h.writeClosed {
+		return 0, net.ErrClosed
+	}
+	if h.writeDeadline.expired {
+		return 0, os.ErrDeadlineExceeded
+	}
+	if h.readClosed {
+		return 0, errClosedByPeer
+	}
+	if h.writeErr != nil {
+		return 0, h.writeErr
+	}
+	writeMax := h.bufMax - h.buf.Len()
+	if writeMax < len(b) {
+		b = b[:writeMax]
+	}
+	return h.buf.Write(b)
+}
+
+type connDeadline struct {
+	timer   *time.Timer
+	expired bool
+}
+
+type locker interface {
+	lock()
+	unlock()
+}
+
+func (d *connDeadline) setDeadline(mu locker, t time.Time) {
+	mu.lock()
+	defer mu.unlock()
+	if d.timer != nil {
+		d.timer.Stop()
+		d.timer = nil
+	}
+	if t.IsZero() {
+		// No deadline.
+		d.expired = false
+		return
+	}
+	expiry := time.Until(t)
+	if expiry <= 0 {
+		// Deadline has already passed.
+		d.expired = true
+		return
+	}
+	// Deadline is in the future.
+	d.expired = false
+	var timer *time.Timer
+	timer = time.AfterFunc(expiry, func() {
+		mu.lock()
+		defer mu.unlock()
+		if d.timer == timer {
+			d.timer = nil
+			d.expired = true
+		}
+	})
+	d.timer = timer
+}

--- a/internal/testserver/testserver.go
+++ b/internal/testserver/testserver.go
@@ -112,7 +112,7 @@ type Instance struct {
 	packetReceived  func(publish *packets.ControlPacket) error      // Will be called when a packet is received (return error to drop connection)
 	overrideConnAck func(cp *packets.Connect, cap *packets.Connack) // Will be called before CONNECT response transmitted, cap can be modified
 
-	// Below are not thread-safe (should only be accessed after checking connected)
+	// Variables below are not thread-safe (should only be accessed after checking connected)
 	connPktDone           bool                    // true if we have processed a CONNECT packet (ever!)
 	sessionPresent        bool                    // true if a session exists
 	sessionExpiryInterval uint32                  // as set on the most recent `connect` (we treat anything >0 as infinite)
@@ -616,27 +616,12 @@ func (m *MIDs) Clear() {
 	m.index = make([]bool, int(midMax))
 }
 
-// netPipe simulates a network link using a real connection.
+// netPipe simulates a network link.
 // This is used over net.Pipe because net.Pipe is synchronous and this can create confusing results
 // because it does not work like a real network connection (a call to `Write` will block until the other
-// end calls `Read` whereas with a real connection there are buffers etc).
-// There are many ways to do this, but using a real connection is simple and effective!
+// end calls `Read` whereas with a real connection there are buffers etc.).
+// Previously a real local TCP connection was used, but that did not work with `synctest`.
 func netPipe(ctx context.Context) (net.Conn, net.Conn, error) {
-	var lc net.ListenConfig
-	l, err := lc.Listen(ctx, "tcp", "127.0.0.1:0") // Port 0 is wildcard port; OS will choose port for us
-	if err != nil {
-		return nil, nil, err
-	}
-	defer l.Close()
-	var d net.Dialer
-	userCon, err := d.DialContext(ctx, "tcp", l.Addr().String()) // Dial the port we just listened on
-	if err != nil {
-		return nil, nil, err
-	}
-	ourCon, err := l.Accept() // Should return immediately
-	if err != nil {
-		userCon.Close()
-		return nil, nil, err
-	}
-	return userCon, ourCon, nil
+	a, b := NewConnPair()
+	return a, b, nil
 }

--- a/internal/testserver/testserver.go
+++ b/internal/testserver/testserver.go
@@ -158,19 +158,20 @@ func (i *Instance) Connected() bool {
 // Returns a net.Conn (to pass to paho), a channel that will be closed when connection has shutdown and
 // an error (if any).
 func (i *Instance) Connect(ctx context.Context) (net.Conn, chan struct{}, error) {
+	if err := ctx.Err(); err != nil { // Fail fast
+		return nil, nil, err
+	}
+
 	if !i.connected.CompareAndSwap(false, true) {
 		return nil, nil, errors.New("already connected") // We only support a single connection
 	}
 	i.connPktDone = false // Connection packet should be the first thing we receive after each connection
 
-	userCon, ourCon, err := netPipe(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
+	c1, c2 := NewConnPair()
 
 	// Ensure both connections support thread safe writes
-	userCon = packets.NewThreadSafeConn(userCon)
-	ourCon = packets.NewThreadSafeConn(ourCon) // Should not be necessary but may avoid hard to spot bugs
+	userCon := packets.NewThreadSafeConn(c1)
+	ourCon := packets.NewThreadSafeConn(c2) // Should not be necessary but may avoid hard to spot bugs
 
 	done := make(chan struct{})
 	go func() {
@@ -614,14 +615,4 @@ func (m *MIDs) Free(i uint16) {
 // Note: Does not reset lastMid because retaining a sequence can make debugging easier
 func (m *MIDs) Clear() {
 	m.index = make([]bool, int(midMax))
-}
-
-// netPipe simulates a network link.
-// This is used over net.Pipe because net.Pipe is synchronous and this can create confusing results
-// because it does not work like a real network connection (a call to `Write` will block until the other
-// end calls `Read` whereas with a real connection there are buffers etc.).
-// Previously a real local TCP connection was used, but that did not work with `synctest`.
-func netPipe(ctx context.Context) (net.Conn, net.Conn, error) {
-	a, b := NewConnPair()
-	return a, b, nil
 }

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -947,7 +947,6 @@ func TestDisconnect(t *testing.T) {
 		Conn: ts.ClientConn(),
 	})
 	require.NotNil(t, c)
-	basicClientInitialisation(t.Context(), c)
 	c.SetDebugLogger(clientLogger)
 	defer c.close()
 
@@ -1166,6 +1165,7 @@ func TestAddOnPublishReceived(t *testing.T) {
 
 // basicClientInitialisation initialises a Client that will be used without calling Connect
 // performs the least configuration possible such that calling `close()` will cleanly shutdown
+// Should only be used if `client.Connect()` will not be called.
 func basicClientInitialisation(ctx context.Context, c *Client) context.Context {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	c.cancelFunc = cancelFunc

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -123,7 +123,7 @@ func TestClientSubscribe(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -168,7 +168,7 @@ func TestClientUnsubscribe(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -206,7 +206,7 @@ func TestClientPublishQoS0(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -249,7 +249,7 @@ func TestClientPublishQoS1(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -294,7 +294,7 @@ func TestClientPublishQoS2(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -341,7 +341,7 @@ func TestClientReceiveQoS0(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -388,7 +388,7 @@ func TestClientReceiveQoS1(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -436,7 +436,7 @@ func TestClientReceiveQoS2(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -653,7 +653,7 @@ func TestReceiveServerDisconnect(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -693,7 +693,7 @@ func TestReceiveServerDisconnectNoProps(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(1)
 	go func() {
@@ -747,7 +747,7 @@ func testAuthenticate(t *testing.T, wantSucces bool, response packets.Packet) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(t.Context(), c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
@@ -867,20 +867,19 @@ func TestAuthenticateOnConnect(t *testing.T) {
 func TestCleanup(t *testing.T) {
 	serverLogger := paholog.NewTestLogger(t, "TestServer:")
 	ts := basictestserver.New(serverLogger)
-	go ts.Run()
+	var wg sync.WaitGroup
+	wg.Go(ts.Run)
 
 	c := NewClient(ClientConfig{
 		Conn: ts.ClientConn(),
 	})
 	require.NotNil(t, c)
-	basicClientInitialisation(c)
-
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancelling to make the client fail on the connection attempt
 	ca, err := c.Connect(ctx, &Connect{
 		ClientID: "testClient",
 	})
-	require.True(t, errors.Is(err, context.Canceled))
+	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, ca)
 
 	// client should have shutdown cleanly (and waited before returning)
@@ -893,6 +892,8 @@ func TestCleanup(t *testing.T) {
 
 	// verify that it's possible to try again
 	ts.Stop()
+	wg.Wait()
+	wg = sync.WaitGroup{}
 	ts = basictestserver.New(serverLogger)
 	ts.SetResponse(packets.CONNACK, &packets.Connack{
 		ReasonCode:     0,
@@ -904,8 +905,7 @@ func TestCleanup(t *testing.T) {
 			TopicAliasMaximum: Uint16(200),
 		},
 	})
-	go ts.Run()
-	defer ts.Stop()
+	wg.Go(ts.Run)
 
 	ctx = context.Background()
 	c = NewClient(ClientConfig{
@@ -922,6 +922,9 @@ func TestCleanup(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, uint8(0), ca.ReasonCode)
+
+	ts.Stop()
+	wg.Wait()
 }
 
 func TestDisconnect(t *testing.T) {
@@ -944,7 +947,7 @@ func TestDisconnect(t *testing.T) {
 		Conn: ts.ClientConn(),
 	})
 	require.NotNil(t, c)
-	basicClientInitialisation(c)
+	basicClientInitialisation(t.Context(), c)
 	c.SetDebugLogger(clientLogger)
 	defer c.close()
 
@@ -1163,8 +1166,8 @@ func TestAddOnPublishReceived(t *testing.T) {
 
 // basicClientInitialisation initialises a Client that will be used without calling Connect
 // performs the least configuration possible such that calling `close()` will cleanly shutdown
-func basicClientInitialisation(c *Client) context.Context {
-	ctx, cancelFunc := context.WithCancel(context.Background())
+func basicClientInitialisation(ctx context.Context, c *Client) context.Context {
+	ctx, cancelFunc := context.WithCancel(ctx)
 	c.cancelFunc = cancelFunc
 	done := make(chan struct{})
 	c.done = done

--- a/paho/default_pinger_test.go
+++ b/paho/default_pinger_test.go
@@ -18,9 +18,12 @@ package paho
 import (
 	"context"
 	"net"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/eclipse/paho.golang/internal/testserver"
 	"github.com/eclipse/paho.golang/packets"
 	paholog "github.com/eclipse/paho.golang/paho/log"
 	"github.com/stretchr/testify/assert"
@@ -29,254 +32,236 @@ import (
 )
 
 func TestDefaultPingerTimeout(t *testing.T) {
-	fakeServerConn, fakeClientConn := net.Pipe()
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		// Use buffered connection (so no need to resd/throw away data)
+		fakeServerConn, fakeClientConn := testserver.NewConnPair()
+		defer fakeServerConn.Close()
 
-	go func() {
-		// keep reading from fakeServerConn and throw away the data
-		buf := make([]byte, 1024)
-		for {
-			_, err := fakeServerConn.Read(buf)
-			if err != nil {
-				return
-			}
-		}
-	}()
-	defer fakeServerConn.Close()
+		pinger := NewDefaultPinger()
+		pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
 
-	pinger := NewDefaultPinger()
-	pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
+		// Allow pinger to run for 10 seconds (should exit after 1 because first ping sent immediately)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	pingResult := make(chan error, 1)
-	go func() {
-		pingResult <- pinger.Run(ctx, fakeClientConn, 1)
-	}()
+		startTime := time.Now()
+		pingErr := pinger.Run(ctx, fakeClientConn, 1)
+		duration := time.Since(startTime)
 
-	select {
-	case err := <-pingResult:
-		require.NotNil(t, err)
-		assert.EqualError(t, err, "PINGRESP timed out")
-	case <-time.After(10 * time.Second):
-		t.Error("expected DefaultPinger to detect timeout and return error")
-	}
+		require.GreaterOrEqual(t, duration.Seconds(), 1.0, "Expected pinger to run for at least 1 second")
+		assert.EqualError(t, pingErr, "PINGRESP timed out")
+	})
 }
 
 func TestDefaultPingerSuccess(t *testing.T) {
-	fakeClientConn, fakeServerConn := net.Pipe()
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		// Everything will shut down after 10 seconds, after which results will be checked
+		var wg sync.WaitGroup
+		startTime := time.Now()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
-	pinger := NewDefaultPinger()
-	pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
+		fakeClientConn, fakeServerConn := testserver.NewConnPair()
+		context.AfterFunc(ctx, func() {
+			fakeServerConn.Close()
+		})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	pingResult := make(chan error, 1)
-	go func() {
-		pingResult <- pinger.Run(ctx, fakeClientConn, 3)
-	}()
+		pinger := NewDefaultPinger()
+		pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
 
-	go func() {
-		// keep reading from fakeServerConn and call PingResp() when a PINGREQ is received
-		for {
-			recv, err := packets.ReadPacket(fakeServerConn)
-			if err != nil {
-				return
+		var pingErr error
+		var duration time.Duration
+		wg.Go(func() {
+			pingErr = pinger.Run(ctx, fakeClientConn, 3)
+			duration = time.Since(startTime)
+			fakeServerConn.Close() // Allow goroutine handling comms to close
+		})
+
+		wg.Go(func() {
+			// keep reading from fakeServerConn and call PingResp() when a PINGREQ is received
+			for {
+				recv, err := packets.ReadPacket(fakeServerConn)
+				if err != nil {
+					return
+				}
+				if recv.Type == packets.PINGREQ {
+					pinger.PingResp()
+				}
 			}
-			if recv.Type == packets.PINGREQ {
-				pinger.PingResp()
-			}
-		}
-	}()
-	defer fakeServerConn.Close()
+		})
 
-	select {
-	case err := <-pingResult:
-		t.Errorf("expected DefaultPinger to not return error, got %v", err)
-	case <-time.After(10 * time.Second):
-		// PASS
-	}
+		wg.Wait()
+		require.GreaterOrEqual(t, duration.Seconds(), 10.0, "Expected pinger to run for at least 10 seconds")
+		require.NoError(t, pingErr)
+	})
 }
 
 func TestDefaultPingerPacketSentReceived(t *testing.T) {
-	fakeClientConn, fakeServerConn := net.Pipe()
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		// Everything will shut down after 10 seconds, after which results will be checked
+		var wg sync.WaitGroup
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		fakeClientConn, fakeServerConn := testserver.NewConnPair()
+		context.AfterFunc(ctx, func() {
+			fakeServerConn.Close()
+		})
 
-	pinger := NewDefaultPinger()
-	pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
+		pinger := NewDefaultPinger()
+		pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	pingResult := make(chan error, 1)
-	go func() {
-		pingResult <- pinger.Run(ctx, fakeClientConn, 3)
-	}()
+		var pingErr error
+		wg.Go(func() {
+			pingErr = pinger.Run(ctx, fakeClientConn, 3) // 3-second keepalive
+		})
 
-	// keep calling PacketSent() (and PacketReceived) in a goroutine to check that the Pinger avoids sending PINGREQs when not needed
-	stop := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
+		// keep calling PacketSent() (and PacketReceived) in a goroutine to check that the Pinger avoids sending PINGREQs when not needed
+		wg.Go(func() {
+			for ctx.Err() == nil {
+				time.Sleep(time.Second) // Ensure initial ping is sent (and avoid tight loop)
+				// Notify pinger that packets have been sent/received (so it should not ping)
+				pinger.PacketSent()
+				pinger.PacketReceived()
+
 			}
-			// keep calling PacketSent() and PacketReceived
-			pinger.PacketSent()
-			pinger.PacketReceived()
-		}
-	}()
-	defer close(stop)
+		})
 
-	// keep reading from fakeServerConn and call PingResp() when a PINGREQ is received
-	// if more than one PINGREQ is received, the test will fail
-	count := 0
-	tooManyPingreqs := make(chan struct{})
-	go func() {
-		for {
+		// read from fakeServerConn and call PingResp() when a PINGREQ is received
+		pingCount := 0
+		var readPacketErr error
+		wg.Go(func() {
 			recv, err := packets.ReadPacket(fakeServerConn)
 			if err != nil {
+				readPacketErr = err
 				return
 			}
 			if recv.Type == packets.PINGREQ {
-				count++
+				pingCount++
 				pinger.PingResp()
-				if count == 2 { // we allow the count to be 1 because the first PINGREQ is sent immediately
-					close(tooManyPingreqs)
-				}
 			}
-		}
-	}()
-	defer fakeServerConn.Close()
+		})
 
-	select {
-	case <-tooManyPingreqs:
-		t.Error("expected DefaultPinger to not send PINGREQs when not needed")
-	case err := <-pingResult:
-		t.Errorf("expected DefaultPinger to not return error, got %v", err)
-	case <-time.After(10 * time.Second):
-		// PASS
-	}
+		// Wait for everything to finnish (10 seconds) and then check result
+		wg.Wait()
+		require.Equal(t, 1, pingCount, "Expected 1 ping") // Initial ping is sent immediately
+		require.NoError(t, pingErr)
+		require.NoError(t, readPacketErr) // terminates after processing packet
+	})
 }
 
 // TestDefaultPingerPacketSentOnly - If packets are being sent, but nothing received, then a pingreq should be sent
 func TestDefaultPingerPacketSentOnly(t *testing.T) {
-	fakeClientConn, fakeServerConn := net.Pipe()
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		var wg sync.WaitGroup
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // Test runs for 10 seconds
+		defer cancel()
 
-	pinger := NewDefaultPinger()
-	pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
+		fakeClientConn, fakeServerConn := testserver.NewConnPair()
+		context.AfterFunc(ctx, func() {
+			fakeServerConn.Close()
+		})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	pingResult := make(chan error, 1)
-	go func() {
-		pingResult <- pinger.Run(ctx, fakeClientConn, 3)
-	}()
+		pinger := NewDefaultPinger()
+		pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
 
-	// keep calling PacketSent() (and PacketReceived) in a goroutine to check that the Pinger avoids sending PINGREQs when not needed
-	stop := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
+		var pingErr error
+		wg.Go(func() {
+			pingErr = pinger.Run(ctx, fakeClientConn, 3)
+		})
+
+		// keep calling PacketSent() in a goroutine to check that the Pinger avoids sending PINGREQs when not needed
+		wg.Go(func() {
+			for ctx.Err() == nil {
+				pinger.PacketSent()
+				time.Sleep(time.Millisecond)
 			}
-			// keep calling PacketSent()
-			pinger.PacketSent()
-		}
-	}()
-	defer close(stop)
+		})
 
-	// keep reading from fakeServerConn and call PingResp() when a PINGREQ is received
-	// if more than one PINGREQ is received, the test will fail
-	count := 0
-	twoPingreqs := make(chan struct{})
-	go func() {
-		for {
-			recv, err := packets.ReadPacket(fakeServerConn)
-			if err != nil {
-				return
-			}
-			if recv.Type == packets.PINGREQ {
-				count++
-				pinger.PingResp()
-				if count == 2 {
-					close(twoPingreqs)
+		// keep reading from fakeServerConn and call PingResp() when a PINGREQ is received
+		// if more than one PINGREQ is received, the test will fail
+		pingCount := 0
+		var readPacketErr error
+		wg.Go(func() {
+			for {
+				recv, err := packets.ReadPacket(fakeServerConn)
+				if err != nil {
+					readPacketErr = err
+					return
+				}
+				if recv.Type == packets.PINGREQ {
+					pingCount++
+					pinger.PingResp()
 				}
 			}
-		}
-	}()
-	defer fakeServerConn.Close()
+		})
 
-	select {
-	case <-twoPingreqs:
-		// pass
-	case err := <-pingResult:
-		t.Errorf("expected DefaultPinger to not return error, got %v", err)
-	case <-time.After(10 * time.Second):
-		t.Error("expected DefaultPinger to send PINGREQs when no packets received")
-	}
+		wg.Wait()                                          // wait for test to run
+		require.Equal(t, 4, pingCount, "Expected 4 pings") // 0,3,6,9 seconds
+		require.NoError(t, pingErr)
+		require.ErrorIs(t, readPacketErr, net.ErrClosed)
+	})
 }
 
 // TestDefaultPingerPacketReceiveOnly - If packets are being received, but nothing sent, then a pingreq should be sent
 func TestDefaultPingerPacketReceiveOnly(t *testing.T) {
-	fakeClientConn, fakeServerConn := net.Pipe()
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		var wg sync.WaitGroup
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // Test runs for 10 seconds
+		defer cancel()
 
-	pinger := NewDefaultPinger()
-	pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
+		fakeClientConn, fakeServerConn := testserver.NewConnPair()
+		context.AfterFunc(ctx, func() {
+			fakeServerConn.Close()
+		})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	pingResult := make(chan error, 1)
-	go func() {
-		pingResult <- pinger.Run(ctx, fakeClientConn, 3)
-	}()
+		pinger := NewDefaultPinger()
+		pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
 
-	// keep calling PacketSent() (and PacketReceived) in a goroutine to check that the Pinger avoids sending PINGREQs when not needed
-	stop := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
+		var pingErr error
+		wg.Go(func() {
+			pingErr = pinger.Run(ctx, fakeClientConn, 3)
+		})
+
+		// keep calling PacketSent() in a goroutine to check that the Pinger avoids sending PINGREQs when not needed
+		wg.Go(func() {
+			for ctx.Err() == nil {
+				pinger.PacketReceived()
+				time.Sleep(time.Millisecond)
 			}
-			pinger.PacketReceived()
-		}
-	}()
-	defer close(stop)
+		})
 
-	// keep reading from fakeServerConn and call PingResp() when a PINGREQ is received
-	// if more than one PINGREQ is received, the test will fail
-	count := 0
-	twoPingreqs := make(chan struct{})
-	go func() {
-		for {
-			recv, err := packets.ReadPacket(fakeServerConn)
-			if err != nil {
-				return
-			}
-			if recv.Type == packets.PINGREQ {
-				count++
-				pinger.PingResp()
-				if count == 2 {
-					close(twoPingreqs)
+		// keep reading from fakeServerConn and call PingResp() when a PINGREQ is received
+		// if more than one PINGREQ is received, the test will fail
+		pingCount := 0
+		var readPacketErr error
+		wg.Go(func() {
+			for {
+				recv, err := packets.ReadPacket(fakeServerConn)
+				if err != nil {
+					readPacketErr = err
+					return
+				}
+				if recv.Type == packets.PINGREQ {
+					pingCount++
+					pinger.PingResp()
 				}
 			}
-		}
-	}()
-	defer fakeServerConn.Close()
+		})
 
-	select {
-	case <-twoPingreqs:
-		// pass
-	case err := <-pingResult:
-		t.Errorf("expected DefaultPinger to not return error, got %v", err)
-	case <-time.After(10 * time.Second):
-		t.Error("expected DefaultPinger to send PINGREQs when no packets sent")
-	}
+		wg.Wait()                                          // wait for test to run
+		require.Equal(t, 4, pingCount, "Expected 4 pings") // 0,3,6,9 seconds
+		require.NoError(t, pingErr)
+		require.ErrorIs(t, readPacketErr, net.ErrClosed)
+	})
 }
 
 func TestDefaultPingerStartStop(t *testing.T) {
+	t.Parallel()
 	fakeServerConn, fakeClientConn := net.Pipe()
 
 	go func() {

--- a/paho/default_pinger_test.go
+++ b/paho/default_pinger_test.go
@@ -125,7 +125,6 @@ func TestDefaultPingerPacketSentReceived(t *testing.T) {
 				// Notify pinger that packets have been sent/received (so it should not ping)
 				pinger.PacketSent()
 				pinger.PacketReceived()
-
 			}
 		})
 
@@ -133,14 +132,16 @@ func TestDefaultPingerPacketSentReceived(t *testing.T) {
 		pingCount := 0
 		var readPacketErr error
 		wg.Go(func() {
-			recv, err := packets.ReadPacket(fakeServerConn)
-			if err != nil {
-				readPacketErr = err
-				return
-			}
-			if recv.Type == packets.PINGREQ {
-				pingCount++
-				pinger.PingResp()
+			for {
+				recv, err := packets.ReadPacket(fakeServerConn)
+				if err != nil {
+					readPacketErr = err
+					return
+				}
+				if recv.Type == packets.PINGREQ {
+					pingCount++
+					pinger.PingResp()
+				}
 			}
 		})
 
@@ -148,7 +149,7 @@ func TestDefaultPingerPacketSentReceived(t *testing.T) {
 		wg.Wait()
 		require.Equal(t, 1, pingCount, "Expected 1 ping") // Initial ping is sent immediately
 		require.NoError(t, pingErr)
-		require.NoError(t, readPacketErr) // terminates after processing packet
+		require.ErrorIs(t, readPacketErr, net.ErrClosed)
 	})
 }
 

--- a/paho/packet_ids_test.go
+++ b/paho/packet_ids_test.go
@@ -17,6 +17,7 @@ package paho
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,7 +31,13 @@ import (
 // TestPackedIdNoExhaustion tests interactions between Publish and the session ensuring that IDs are
 // released and reused
 func TestPackedIdNoExhaustion(t *testing.T) {
-	ts := basictestserver.New(paholog.NewTestLogger(t, "TestServer:"))
+	t.Parallel()
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute) // Should finnish in a few seconds, but does a lot of work
+	defer cancel()
+
+	// Logging doubles test runtime - If issues are encountered, use `paholog.NewTestLogger(t, "TestServer:")`
+	ts := basictestserver.New(paholog.NOOPLogger{})
 	ts.SetResponse(packets.PUBACK, &packets.Puback{
 		ReasonCode: packets.PubackSuccess,
 		Properties: &packets.Properties{},
@@ -43,10 +50,10 @@ func TestPackedIdNoExhaustion(t *testing.T) {
 	})
 	require.NotNil(t, c)
 
-	clientCtx := basicClientInitialisation(c)
+	clientCtx := basicClientInitialisation(ctx, c)
 	c.publishPackets = make(chan *packets.Publish)
-	go c.incoming(clientCtx)
-	go c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
+	wg.Go(func() { c.incoming(clientCtx) })
+	wg.Go(func() { c.config.PingHandler.Run(clientCtx, c.config.Conn, 30) })
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	for i := 0; i < 70000; i++ {
@@ -61,9 +68,11 @@ func TestPackedIdNoExhaustion(t *testing.T) {
 		assert.Equal(t, uint8(0), pa.ReasonCode)
 	}
 
-	time.Sleep(10 * time.Millisecond)
+	// Ensure things shutdown
+	cancel()
+	wg.Wait()
 }
 
 // Note: We no longer test for Packet Id Exhaustion because the way the CONNACK Receive Maximum now works makes
-// this impossible (the semaphore will lock on the 65536th request and only unlock when a response is received
+// this impossible (the semaphore will lock on the 65536th request and only unlock when a response is received,
 // which would also mean an ID is available).


### PR DESCRIPTION
With the move to Go 1.25 we can now use synctest. This PR significantly reduces test runtime and should improve reliability.

Note that the method used to simulate a network connection was not compatible with synctest so a new method (copied from the current Go source) has been used. 


ref #242 
