### PR TITLE
feat: add ReadPacketN with maximum packet size limit

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -241,17 +241,24 @@ func NewControlPacket(t byte) *ControlPacket {
 }
 
 // ReadPacket reads a control packet from a io.Reader and returns a completed
-// struct with the appropriate data
+// struct with the appropriate data.
 func ReadPacket(r io.Reader) (*ControlPacket, error) {
+	return ReadPacketN(r, 0)
+}
+
+// ReadPacketN reads a control packet from an io.Reader and returns a completed
+// struct with the appropriate data. If maxSize is greater than zero and the
+// total packet size (fixed header + variable header + payload) exceeds maxSize,
+// the packet is rejected with an error. This protects against a malicious broker
+// sending oversized packets that could cause the client to run out of memory.
+// As per MQTT v5.0 spec section 4.13, a client should DISCONNECT with Reason
+// Code 0x95 (Packet too large) upon receiving an oversize packet.
+func ReadPacketN(r io.Reader, maxSize int) (*ControlPacket, error) {
 	t := [1]byte{}
 	_, err := io.ReadFull(r, t[:])
 	if err != nil {
 		return nil, err
 	}
-	// cp := NewControlPacket(PacketType(t[0] >> 4))
-	// if cp == nil {
-	// 	return nil, fmt.Errorf("invalid packet type requested, %d", t[0]>>4)
-	// }
 
 	pt := t[0] >> 4
 	cp := &ControlPacket{FixedHeader: FixedHeader{Type: pt}}
@@ -308,9 +315,19 @@ func ReadPacket(r io.Reader) (*ControlPacket, error) {
 	if err != nil {
 		return nil, err
 	}
+	vbiLen := vbi.Len()
 	cp.remainingLength, err = decodeVBI(vbi)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check packet size against maximum before allocating the payload buffer.
+	// Total packet size = 1 (fixed header byte) + VBI length + remaining length.
+	if maxSize > 0 {
+		packetSize := 1 + vbiLen + cp.remainingLength
+		if packetSize > maxSize {
+			return nil, fmt.Errorf("packet size %d exceeds maximum allowed %d (MQTT 5.0 Reason Code 0x95: Packet too large)", packetSize, maxSize)
+		}
 	}
 
 	b := make([]byte, cp.remainingLength)

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -181,6 +181,54 @@ func TestReadPacketConnect(t *testing.T) {
 	assert.Equal(t, uint32(30), *c.Content.(*Connect).Properties.SessionExpiryInterval)
 }
 
+func TestReadPacketNConnect(t *testing.T) {
+	// Same packet as TestReadPacketConnect
+	p := []byte{16, 38, 0, 4, 77, 81, 84, 84, 5, 128, 0, 30, 5, 17, 0, 0, 0, 30, 0, 10, 116, 101, 115, 116, 67, 108, 105, 101, 110, 116, 0, 8, 116, 101, 115, 116, 85, 115, 101, 114}
+
+	// With maxSize=0 (no limit) should behave like ReadPacket
+	c, err := ReadPacketN(bufio.NewReader(bytes.NewReader(p)), 0)
+	require.Nil(t, err)
+	assert.Equal(t, uint16(30), c.Content.(*Connect).KeepAlive)
+	assert.Equal(t, "testClient", c.Content.(*Connect).ClientID)
+
+	// With a large enough maxSize should succeed
+	c, err = ReadPacketN(bufio.NewReader(bytes.NewReader(p)), 1024)
+	require.Nil(t, err)
+	assert.Equal(t, "testClient", c.Content.(*Connect).ClientID)
+
+	// With a maxSize smaller than the packet should fail
+	_, err = ReadPacketN(bufio.NewReader(bytes.NewReader(p)), 10)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.Contains(t, err.Error(), "Packet too large")
+}
+
+func TestReadPacketNPingreq(t *testing.T) {
+	// PINGREQ is the simplest packet: type 0xC0, remaining length 0 (2 bytes total)
+	p := []byte{0xC0, 0x00}
+
+	// Should succeed with maxSize=0 (no limit)
+	c, err := ReadPacketN(bufio.NewReader(bytes.NewReader(p)), 0)
+	require.Nil(t, err)
+	assert.Equal(t, byte(PINGREQ), c.Type)
+
+	// Should succeed with enough room
+	c, err = ReadPacketN(bufio.NewReader(bytes.NewReader(p)), 100)
+	require.Nil(t, err)
+	assert.Equal(t, byte(PINGREQ), c.Type)
+
+	// Should succeed at exact boundary (2 bytes)
+	c, err = ReadPacketN(bufio.NewReader(bytes.NewReader(p)), 2)
+	require.Nil(t, err)
+	assert.Equal(t, byte(PINGREQ), c.Type)
+
+	// Should fail with maxSize=1 (packet is 2 bytes total)
+	_, err = ReadPacketN(bufio.NewReader(bytes.NewReader(p)), 1)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.Contains(t, err.Error(), "Packet too large")
+}
+
 func TestReadStringWriteString(t *testing.T) {
 	var b bytes.Buffer
 	const test1 = "Test string 世界" // include unicode


### PR DESCRIPTION
## Summary

Adds `ReadPacketN(r io.Reader, maxSize int)` — a variant of `ReadPacket` that rejects packets exceeding a caller-specified size limit before allocating memory for the payload.

## Motivation (Fixes #336)

A malicious broker could cause a client to run out of memory by sending very large packets (up to 256MB per the MQTT spec). The CONNECT packet's `Maximum Packet Size` property tells the broker the client's limit, but `ReadPacket` never enforced it. This change lets callers pass that limit and get an early rejection.

## Implementation

- `ReadPacketN` reads the fixed header and VBI as before, then checks `1 + vbiLen + remainingLength > maxSize` **before** allocating the payload buffer
- `ReadPacket` now delegates to `ReadPacketN(r, 0)` — full backward compatibility (maxSize=0 means no limit)
- Error message references MQTT 5.0 Reason Code 0x95 (Packet too large) per spec section 4.13

## Tests

- `TestReadPacketNConnect`: no-limit, large-limit, and undersized-limit with a CONNECT packet
- `TestReadPacketNPingreq`: boundary tests (exact match, under limit) with the simplest 2-byte PINGREQ packet

All existing tests pass.