### PR TITLE
fix: enforce Maximum Packet Size in ReadPacket

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -241,8 +241,16 @@ func NewControlPacket(t byte) *ControlPacket {
 }
 
 // ReadPacket reads a control packet from a io.Reader and returns a completed
-// struct with the appropriate data
+// struct with the appropriate data.
 func ReadPacket(r io.Reader) (*ControlPacket, error) {
+	return ReadPacketN(r, 0)
+}
+
+// ReadPacketN reads a control packet from an io.Reader and returns a completed
+// struct with the appropriate data. If maxSize is greater than zero, packets
+// exceeding that size are rejected before the payload is allocated (as per
+// MQTT v5.0 spec section 3.2.2.3.10).
+func ReadPacketN(r io.Reader, maxSize uint32) (*ControlPacket, error) {
 	t := [1]byte{}
 	_, err := io.ReadFull(r, t[:])
 	if err != nil {
@@ -308,9 +316,19 @@ func ReadPacket(r io.Reader) (*ControlPacket, error) {
 	if err != nil {
 		return nil, err
 	}
+	vbiLen := vbi.Len()
 	cp.remainingLength, err = decodeVBI(vbi)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check maximum packet size before allocating the payload buffer.
+	// Total packet size = 1 (type/flags byte) + VBI length + remaining length.
+	if maxSize > 0 {
+		packetSize := uint32(1+vbiLen) + uint32(cp.remainingLength)
+		if packetSize > maxSize {
+			return nil, fmt.Errorf("packet size %d exceeds maximum allowed %d", packetSize, maxSize)
+		}
 	}
 
 	b := make([]byte, cp.remainingLength)

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -181,6 +181,32 @@ func TestReadPacketConnect(t *testing.T) {
 	assert.Equal(t, uint32(30), *c.Content.(*Connect).Properties.SessionExpiryInterval)
 }
 
+func TestReadPacketNMaxSize(t *testing.T) {
+	// Build a CONNECT packet (40 bytes total)
+	p := []byte{16, 38, 0, 4, 77, 81, 84, 84, 5, 128, 0, 30, 5, 17, 0, 0, 0, 30, 0, 10, 116, 101, 115, 116, 67, 108, 105, 101, 110, 116, 0, 8, 116, 101, 115, 116, 85, 115, 101, 114}
+	require.Equal(t, 40, len(p))
+
+	// maxSize=0 means no limit — should succeed
+	c, err := ReadPacketN(bytes.NewReader(p), 0)
+	require.NoError(t, err)
+	assert.Equal(t, "testClient", c.Content.(*Connect).ClientID)
+
+	// maxSize larger than packet — should succeed
+	c, err = ReadPacketN(bytes.NewReader(p), 100)
+	require.NoError(t, err)
+	assert.Equal(t, "testClient", c.Content.(*Connect).ClientID)
+
+	// maxSize equal to packet — should succeed
+	c, err = ReadPacketN(bytes.NewReader(p), 40)
+	require.NoError(t, err)
+	assert.Equal(t, "testClient", c.Content.(*Connect).ClientID)
+
+	// maxSize smaller than packet — should reject before allocating payload
+	_, err = ReadPacketN(bytes.NewReader(p), 39)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
 func TestReadStringWriteString(t *testing.T) {
 	var b bytes.Buffer
 	const test1 = "Test string 世界" // include unicode

--- a/paho/client.go
+++ b/paho/client.go
@@ -489,7 +489,7 @@ func (c *Client) incoming(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		default:
-			recv, err := packets.ReadPacket(c.config.Conn)
+			recv, err := packets.ReadPacketN(c.config.Conn, c.serverProps.MaximumPacketSize)
 			if err != nil {
 				go c.error(err)
 				return


### PR DESCRIPTION
## Summary

Adds `ReadPacketN` to the `packets` package that accepts a `maxSize uint32` parameter. When `maxSize > 0`, packets exceeding the limit are rejected **before** the payload buffer is allocated, preventing a hostile broker from causing OOM by sending oversized packets.

The client's `incoming()` loop now uses `ReadPacketN` with the server's `MaximumPacketSize` (from CONNACK properties) to enforce the limit.

Fixes #336 (and the long-standing #3).

## Changes

- **`packets/packets.go`**: New `ReadPacketN(r io.Reader, maxSize uint32) (*ControlPacket, error)` function. `ReadPacket` now delegates to `ReadPacketN` with `maxSize=0` (no limit) for backward compatibility.
- **`paho/client.go`**: `incoming()` uses `packets.ReadPacketN(c.config.Conn, c.serverProps.MaximumPacketSize)`.
- **`packets/packets_test.go`**: `TestReadPacketNMaxSize` covering no-limit, above-limit, at-limit, and below-limit cases.

## Notes

- The size check happens after reading the fixed header + VBI but **before** allocating `make([]byte, remainingLength)` — this is the key safety property.
- Per MQTT v5.0 spec §3.2.2.3.10, the server's Maximum Packet Size applies to packets sent from server to client.
- Related: #3, #114 (closed, stale)
