### PR TITLE
Harden session state across connections

### DIFF
--- a/paho/client.go
+++ b/paho/client.go
@@ -358,7 +358,7 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 		defer c.workers.Done()
 		defer c.debug.Println("returning from ping handler worker")
 		if err := c.config.PingHandler.Run(clientCtx, c.config.Conn, keepalive); err != nil {
-			go c.error(fmt.Errorf("ping handler error: %w", err))
+			c.reportError(fmt.Errorf("ping handler error: %w", err))
 		}
 	}()
 
@@ -491,14 +491,14 @@ func (c *Client) incoming(ctx context.Context) {
 		default:
 			recv, err := packets.ReadPacket(c.config.Conn)
 			if err != nil {
-				go c.error(err)
+				c.reportError(err)
 				return
 			}
 			c.config.PingHandler.PacketReceived()
 			switch recv.Type {
 			case packets.CONNACK:
 				c.debug.Println("received CONNACK (unexpected)")
-				go c.error(fmt.Errorf("received unexpected CONNACK"))
+				c.reportError(fmt.Errorf("received unexpected CONNACK"))
 				return
 			case packets.AUTH:
 				c.debug.Println("received AUTH")
@@ -519,7 +519,7 @@ func (c *Client) incoming(ctx context.Context) {
 				case packets.AuthContinueAuthentication:
 					if c.config.AuthHandler != nil {
 						if _, err := c.config.AuthHandler.Authenticate(AuthFromPacketAuth(ap)).Packet().WriteTo(c.config.Conn); err != nil {
-							go c.error(err)
+							c.reportError(err)
 							return
 						}
 						c.config.PingHandler.PacketSent()
@@ -528,7 +528,9 @@ func (c *Client) incoming(ctx context.Context) {
 			case packets.PUBLISH:
 				pb := recv.Content.(*packets.Publish)
 				if pb.QoS > 0 { // QOS1 or 2 need to be recorded in session state
-					c.config.Session.PacketReceived(recv, c.publishPackets)
+					if c.handleSessionPacketError(ctx, recv.Type, c.config.Session.PacketReceived(recv, c.publishPackets)) {
+						return
+					}
 				} else {
 					c.debug.Printf("received QoS%d PUBLISH", pb.QoS)
 					select {
@@ -538,7 +540,9 @@ func (c *Client) incoming(ctx context.Context) {
 					}
 				}
 			case packets.PUBACK, packets.PUBCOMP, packets.SUBACK, packets.UNSUBACK, packets.PUBREC, packets.PUBREL:
-				c.config.Session.PacketReceived(recv, c.publishPackets)
+				if c.handleSessionPacketError(ctx, recv.Type, c.config.Session.PacketReceived(recv, c.publishPackets)) {
+					return
+				}
 			case packets.DISCONNECT:
 				pd := recv.Content.(*packets.Disconnect)
 				c.debug.Println("received DISCONNECT")
@@ -550,14 +554,24 @@ func (c *Client) incoming(ctx context.Context) {
 					}
 				}
 				c.authResponseMu.Unlock()
-				c.config.Session.ConnectionLost(pd) // this may impact the session state
-				go func() {
-					if c.config.OnServerDisconnect != nil {
-						go c.serverDisconnect(DisconnectFromPacketDisconnect(pd))
-					} else {
-						go c.error(fmt.Errorf("server initiated disconnect"))
-					}
-				}()
+				if err := c.config.Session.ConnectionLost(pd); err != nil { // this may impact the session state
+					sessionErr := fmt.Errorf("session failed handling connection loss: %w", err)
+					disconnect := DisconnectFromPacketDisconnect(pd)
+					go func() {
+						c.close()
+						if c.config.OnServerDisconnect != nil {
+							go c.config.OnServerDisconnect(disconnect)
+						}
+						go c.config.OnClientError(sessionErr)
+					}()
+					return
+				}
+				if c.config.OnServerDisconnect != nil {
+					c.debug.Println("calling OnServerDisconnect")
+					go c.serverDisconnect(DisconnectFromPacketDisconnect(pd))
+				} else {
+					c.reportError(fmt.Errorf("server initiated disconnect"))
+				}
 				return
 			case packets.PINGRESP:
 				c.debug.Println("received PINGRESP")
@@ -565,6 +579,28 @@ func (c *Client) incoming(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// handleSessionPacketError reports errors raised while processing an incoming session packet. ErrNoConnection is an
+// expected shutdown race when the packet was read before cancellation but handled after session teardown.
+func (c *Client) handleSessionPacketError(ctx context.Context, packetType byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	wrapped := fmt.Errorf("session failed handling packet type %d: %w", packetType, err)
+	if ctx.Err() != nil && errors.Is(err, session.ErrNoConnection) {
+		c.debug.Println("ignoring session packet error during shutdown:", wrapped)
+		return true
+	}
+	c.reportError(wrapped)
+	return true
+}
+
+// reportError records the error then starts shutdown asynchronously.
+// This sequence is used to avoid races in tests
+func (c *Client) reportError(e error) {
+	c.debug.Println("error called:", e)
+	go c.error(e)
 }
 
 // close terminates the connection and waits for a clean shutdown
@@ -582,7 +618,9 @@ func (c *Client) shutdown(done chan<- struct{}) {
 	c.debug.Println("conn closed")
 	c.acksTracker.reset()
 	c.debug.Println("acks tracker reset")
-	c.config.Session.ConnectionLost(nil)
+	if err := c.config.Session.ConnectionLost(nil); err != nil {
+		c.errors.Println("error updating session after connection loss", err)
+	}
 	if c.config.autoCloseSession {
 		if err := c.config.Session.Close(); err != nil {
 			c.errors.Println("error closing session", err)
@@ -599,14 +637,12 @@ func (c *Client) shutdown(done chan<- struct{}) {
 // which results in the other client goroutines terminating.
 // It also closes the client network connection.
 func (c *Client) error(e error) {
-	c.debug.Println("error called:", e)
 	c.close()
 	go c.config.OnClientError(e)
 }
 
 func (c *Client) serverDisconnect(d *Disconnect) {
 	c.close()
-	c.debug.Println("calling OnServerDisconnect")
 	go c.config.OnServerDisconnect(d)
 }
 
@@ -684,9 +720,9 @@ func (c *Client) Subscribe(ctx context.Context, s *Subscribe) (*Suback, error) {
 
 	c.debug.Printf("subscribing to %+v", s.Subscriptions)
 
-	ret := make(chan packets.ControlPacket, 1)
 	sp := s.Packet()
-	if err := c.config.Session.AddToSession(ctx, sp, ret); err != nil {
+	ret, err := c.config.Session.AddToSession(ctx, sp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -749,9 +785,9 @@ func (c *Client) Subscribe(ctx context.Context, s *Subscribe) (*Suback, error) {
 // is returned from the function, along with any errors.
 func (c *Client) Unsubscribe(ctx context.Context, u *Unsubscribe) (*Unsuback, error) {
 	c.debug.Printf("unsubscribing from %+v", u.Topics)
-	ret := make(chan packets.ControlPacket, 1)
 	up := u.Packet()
-	if err := c.config.Session.AddToSession(ctx, up, ret); err != nil {
+	ret, err := c.config.Session.AddToSession(ctx, up)
+	if err != nil {
 		return nil, err
 	}
 
@@ -865,7 +901,7 @@ func (c *Client) PublishWithOptions(ctx context.Context, p *Publish, o PublishOp
 	case 0:
 		c.debug.Println("sending QoS0 message")
 		if _, err := pb.WriteTo(c.config.Conn); err != nil {
-			go c.error(err)
+			c.reportError(err)
 			return nil, err
 		}
 		c.config.PingHandler.PacketSent()
@@ -882,8 +918,8 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish, o Publis
 	pubCtx, cf := context.WithTimeout(ctx, c.config.PacketTimeout)
 	defer cf()
 
-	ret := make(chan packets.ControlPacket, 1)
-	if err := c.config.Session.AddToSession(pubCtx, pb, ret); err != nil {
+	ret, err := c.config.Session.AddToSession(pubCtx, pb)
+	if err != nil {
 		return nil, err
 	}
 

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -16,6 +16,7 @@
 package paho
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -23,6 +24,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +32,7 @@ import (
 	"github.com/eclipse/paho.golang/internal/basictestserver"
 	"github.com/eclipse/paho.golang/packets"
 	paholog "github.com/eclipse/paho.golang/paho/log"
+	"github.com/eclipse/paho.golang/paho/session"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -714,6 +717,152 @@ func TestReceiveServerDisconnectNoProps(t *testing.T) {
 	case <-rChan:
 	case <-time.After(time.Second):
 		t.Fatalf("Expected OnServerDisconnect to be called")
+	}
+}
+
+// connectionLostErrorSession implements SessionManager whilst overriding ConnectionLost.
+type connectionLostErrorSession struct {
+	session.SessionManager
+	err error
+}
+
+// ConnectionLost return the predefined error
+func (s *connectionLostErrorSession) ConnectionLost(*packets.Disconnect) error {
+	return s.err
+}
+
+// synchronousLogProbe provides a logger that waits for release before completing a Println
+type synchronousLogProbe struct {
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+// Println Log something - this waits for manual release before completing
+func (l *synchronousLogProbe) Println(...interface{}) {
+	l.once.Do(func() {
+		close(l.entered)
+		<-l.release
+	})
+}
+
+// Printf noop
+func (*synchronousLogProbe) Printf(string, ...interface{}) {}
+
+// TestReportErrorLogsBeforeStartingShutdown checks that reportError logs errors before
+// shutting down (not doing this can easily lead to data races)
+func TestReportErrorLogsBeforeStartingShutdown(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	c := NewClient(ClientConfig{Conn: packets.NewThreadSafeConn(clientConn)})
+	basicClientInitialisation(t.Context(), c)
+	logger := &synchronousLogProbe{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	c.SetDebugLogger(logger)
+	reported := make(chan struct{})
+	go func() {
+		c.reportError(errors.New("injected error"))
+		close(reported)
+	}()
+
+	select {
+	case <-logger.entered:
+	case <-time.After(time.Second):
+		t.Fatal("error was not logged")
+	}
+	select {
+	case <-c.done:
+		t.Fatal("shutdown completed before error logging returned")
+	default:
+	}
+	close(logger.release)
+	<-reported
+	<-c.done
+}
+
+// TestHandleSessionPacketErrorSuppressesShutdownRace checks for duplicate error on shutdown
+func TestHandleSessionPacketErrorSuppressesShutdownRace(t *testing.T) {
+	errorReceived := make(chan error, 1)
+	c := NewClient(ClientConfig{OnClientError: func(err error) { errorReceived <- err }})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if !c.handleSessionPacketError(ctx, packets.PUBREC, session.ErrNoConnection) {
+		t.Fatal("shutdown ErrNoConnection was not handled")
+	}
+	select {
+	case err := <-errorReceived:
+		t.Fatalf("OnClientError called during shutdown: %v", err)
+	default:
+	}
+}
+
+// TestReceiveServerDisconnectReportsSessionError confirms that session error is reported on disconnection
+func TestReceiveServerDisconnectReportsSessionError(t *testing.T) {
+	sessionErr := errors.New("injected connection loss failure")
+	errorReceived := make(chan error, 1)
+	disconnectReceived := make(chan struct{}, 1)
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	c := NewClient(ClientConfig{
+		Conn:    packets.NewThreadSafeConn(clientConn),
+		Session: &connectionLostErrorSession{err: sessionErr},
+		OnClientError: func(err error) {
+			errorReceived <- err
+		},
+		OnServerDisconnect: func(*Disconnect) {
+			disconnectReceived <- struct{}{}
+		},
+	})
+	clientCtx := basicClientInitialisation(t.Context(), c)
+	c.publishPackets = make(chan *packets.Publish)
+	c.workers.Add(1)
+	go func() {
+		defer c.workers.Done()
+		c.incoming(clientCtx)
+	}()
+
+	if _, err := (&packets.Disconnect{}).WriteTo(serverConn); err != nil {
+		t.Fatalf("send DISCONNECT: %v", err)
+	}
+
+	select {
+	case err := <-errorReceived:
+		if !errors.Is(err, sessionErr) {
+			t.Fatalf("OnClientError received %v; want wrapped session error", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("OnClientError was not called for the session error")
+	}
+	select {
+	case <-disconnectReceived:
+	case <-time.After(time.Second):
+		t.Fatal("OnServerDisconnect was not called after the session error")
+	}
+	<-c.done
+}
+
+// TestShutdownLogsSessionConnectionLostError confirms session error is reported on disconnect
+func TestShutdownLogsSessionConnectionLostError(t *testing.T) {
+	sessionErr := errors.New("injected shutdown connection loss failure")
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	c := NewClient(ClientConfig{
+		Conn:    packets.NewThreadSafeConn(clientConn),
+		Session: &connectionLostErrorSession{err: sessionErr},
+	})
+	var logs bytes.Buffer
+	c.SetErrorLogger(log.New(&logs, "", 0))
+	done := make(chan struct{})
+
+	c.shutdown(done)
+
+	if !strings.Contains(logs.String(), sessionErr.Error()) {
+		t.Fatalf("error log %q does not contain the session error", logs.String())
 	}
 }
 

--- a/paho/session/session.go
+++ b/paho/session/session.go
@@ -58,10 +58,12 @@ type SessionManager interface {
 	//   - Publish messages will have been written to the store (and will be automatically transmitted if a new connection
 	//     is established before the message is fully acknowledged - subject to state rules in the MQTTv5 spec)
 	//   - Something will be sent to `resp` when either the message is fully acknowledged or the packet is removed from
-	//     the session (in which case nil will be sent).
+	//     the session (in which case the zero value will be sent).
 	//
 	// If the function returns an error, then any actions taken will be rewound prior to return.
-	AddToSession(ctx context.Context, packet Packet, resp chan<- packets.ControlPacket) error
+	// On success it returns a state-owned channel that receives exactly one response and is then closed.
+	// On error it returns a nil channel.
+	AddToSession(ctx context.Context, packet Packet) (<-chan packets.ControlPacket, error)
 
 	// PacketReceived must be called when any packet with a packet identifier is received. It will make any required
 	// response and pass any `PUBLISH` messages that need to be passed to the user via the channel.

--- a/paho/session/state/ids_test.go
+++ b/paho/session/state/ids_test.go
@@ -19,39 +19,31 @@ import (
 	"math"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/eclipse/paho.golang/packets"
 	"github.com/eclipse/paho.golang/paho/session"
 	"github.com/stretchr/testify/assert"
 )
 
-// TestPacketIdAllocateAndFreeAll checks that we can allocate all packet identifiers and that, when freed, a message is always
-// sent to the response channel
+// TestPacketIdAllocateAndFreeAll checks that we can allocate all packet identifiers and that, when freed, a message is
+// always sent to the response channel
 func TestPacketIdAllocateAndFreeAll(t *testing.T) {
 	ss := NewInMemory()
 	ss.clientPackets = make(map[uint16]clientGenerated)
 	ss.inflight = newSendQuota(200) // not testing this but its needed for endClientGenerated to work
 
 	// Use full band
-	cpChan := make(chan packets.ControlPacket)
+	responses := make([]<-chan packets.ControlPacket, 0, midMax)
 	for i := uint16(1); i != 0; i++ {
-		v, _ := ss.allocateNextPacketId(packets.PUBLISH, cpChan)
+		v, response, _ := ss.allocateNextPacketId(packets.PUBLISH)
 		assert.Equal(t, i, v)
+		responses = append(responses, response)
 	}
 
 	// Trying to allocate another ID should fail
-	_, err := ss.allocateNextPacketId(packets.PUBLISH, cpChan)
+	_, response, err := ss.allocateNextPacketId(packets.PUBLISH)
 	assert.ErrorIs(t, err, session.ErrPacketIdentifiersExhausted)
-
-	// Free all Mids
-	allResponded := make(chan struct{})
-	go func() {
-		for i := uint16(0); i < midMax; i++ {
-			<-cpChan
-		}
-		close(allResponded)
-	}()
+	assert.Nil(t, response)
 
 	resp := packets.ControlPacket{
 		Content: nil,
@@ -62,42 +54,25 @@ func TestPacketIdAllocateAndFreeAll(t *testing.T) {
 	}
 	for i := uint16(1); i != 0; i++ {
 		assert.NoError(t, ss.endClientGenerated(i, &resp))
-	}
-	select {
-	case <-allResponded:
-	case <-time.After(time.Second):
-		t.Fatal("did not receive responses")
-	}
-	select {
-	case <-cpChan:
-		t.Fatal("unexpected response")
-	default:
+		if got, ok := <-responses[i-1]; !ok || got.Type != packets.PUBACK {
+			t.Fatalf("response for packet %d is type %d, open=%t; want PUBACK", i, got.Type, ok)
+		}
 	}
 
 	// Allocate all Mids again
+	responses = responses[:0]
 	for i := uint16(1); i != 0; i++ {
-		v, _ := ss.allocateNextPacketId(packets.PUBLISH, cpChan)
+		v, response, _ := ss.allocateNextPacketId(packets.PUBLISH)
 		assert.Equal(t, i, v)
+		responses = append(responses, response)
 	}
 
 	// Closing the store should free all Ids sending a message to the provided channel
-	gotCp := make(chan struct{})
-	go func() {
-		for i := uint16(0); i < midMax; i++ {
-			<-cpChan
+	assert.NoError(t, ss.Close())
+	for i, response := range responses {
+		if got, ok := <-response; !ok || got.Type != 0 {
+			t.Fatalf("close response for packet %d is type %d, open=%t; want zero value", i+1, got.Type, ok)
 		}
-		close(gotCp)
-	}()
-	ss.Close()
-	select {
-	case <-gotCp:
-	case <-time.After(time.Second):
-		t.Fatal("did not receive responses")
-	}
-	select {
-	case <-cpChan:
-		t.Fatal("unexpected response")
-	default:
 	}
 }
 
@@ -107,17 +82,9 @@ func TestPacketIdHoles(t *testing.T) {
 	ss.clientPackets = make(map[uint16]clientGenerated)
 	ss.inflight = newSendQuota(200) // not testing this but its needed for endClientGenerated to work
 
-	// For this test we ignore responses
-	cpChan := make(chan packets.ControlPacket)
-	defer close(cpChan)
-	go func() {
-		for range cpChan {
-		}
-	}()
-
 	// Allocate all Mids
 	for i := uint16(1); i != 0; i++ {
-		v, _ := ss.allocateNextPacketId(packets.PUBLISH, cpChan)
+		v, _, _ := ss.allocateNextPacketId(packets.PUBLISH)
 		assert.Equal(t, i, v)
 	}
 
@@ -140,7 +107,7 @@ func TestPacketIdHoles(t *testing.T) {
 	}
 	t.Log("Num of holes:", len(h))
 	for i := 0; i < len(h); i++ {
-		_, err := ss.allocateNextPacketId(packets.PUBLISH, cpChan)
+		_, _, err := ss.allocateNextPacketId(packets.PUBLISH)
 		assert.Nil(t, err)
 	}
 }

--- a/paho/session/state/state.go
+++ b/paho/session/state/state.go
@@ -42,8 +42,8 @@ import (
 // > resend messages at any other time
 //
 // There are a few other areas where the State is important:
-//    * When allocating a new packet identifier we need to know what Id's are already in the session state.
-//    * If a QOS2 Publish with `DUP=TRUE` is received then we should not pass it to the client if we have previously
+//    * When allocating a new packet identifier, we need to know what IDs are already in the session state.
+//    * If a QOS2 Publish with `DUP=TRUE` is received, then we should not pass it to the client if we have previously
 //    sent a `PUBREC` (indicating that the message has already been processed).
 //    * Some subscribers may need a transaction (i.e. commit transaction when `PUBREL` received), this is not implemented
 //       here, but the option is left open.
@@ -79,7 +79,7 @@ type (
 		packetType byte // The type of the last packet sent (i.e. PUBLISH, SUBSCRIBE or UNSUBSCRIBE) - 0 means unknown until loaded from the store
 
 		// When a message is fully acknowledged, we need to let the requester know by sending the final response to this
-		// channel. One and only one message will be sent (the channel will then be closed to ensure this!).
+		// channel. One and only one message will be sent (and the channel closed).
 		// We also guarantee to always send to the channel (assuming there is a clean shutdown) so that the end user knows
 		// the status of the request.
 		responseChan chan<- packets.ControlPacket
@@ -89,7 +89,7 @@ type (
 // State manages the session state. The client will send messages that may impact the state via
 // us, and we will maintain the session state
 type State struct {
-	mu                    sync.Mutex // protects whole struct (operations should be quick, so the impact of multiple mutexes is likely to be low)
+	mu                    sync.Mutex // protects the whole struct
 	connectionLostAt      time.Time  // Time that the connection was lost
 	sessionExpiryInterval uint32     // The session expiry interval sent with the most recent CONNECT packet
 
@@ -98,13 +98,15 @@ type State struct {
 	connCtxCancel func()          // Cancels the above context
 
 	// client store - holds packets where the message ID was generated on the client (i.e. by paho.golang)
-	clientPackets map[uint16]clientGenerated // Store relating to messages sent TO the server
-	clientStore   storer                     // Used to store session state that survives connection loss
-	lastMid       uint16                     // The message ID most recently issued
+	clientPackets           map[uint16]clientGenerated // Store relating to messages sent TO the server
+	clientStore             storer                     // Used to store session state that survives connection loss
+	clientStoreResetPending bool                       // A failed reset must complete before stored packets can be reused
+	lastMid                 uint16                     // The message ID most recently issued
 
 	// server store - holds packets where the message ID was generated on the server
-	serverPackets map[uint16]byte // The last packet received from the server with this ID (cleared when the transaction is complete)
-	serverStore   storer          // Used to store session state that survives connection loss
+	serverPackets           map[uint16]byte // The last packet received from the server with this ID (cleared when the transaction is complete)
+	serverStore             storer          // Used to store session state that survives connection loss
+	serverStoreResetPending bool            // A failed reset must complete before stored packets can be reused
 
 	// The number of messages in flight needs to be limited, as per receive maximum received from the server.
 	inflight *sendQuota
@@ -136,13 +138,14 @@ func NewInMemory() *State {
 // Close closes the session state
 func (s *State) Close() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.connectionLost(nil) // Connection may be up in which case we need to cleanup.
+	removed, err := s.connectionLost(nil) // Connection may be up in which case we need to cleanup.
 	for packetID, cg := range s.clientPackets {
-		cg.responseChan <- packets.ControlPacket{} // Default control packet indicates that we are shutting down (TODO: better solution?)
+		removed = append(removed, cg) // Want to notify without holding mu
 		delete(s.clientPackets, packetID)
 	}
-	return nil
+	s.mu.Unlock()
+	notifyRemoved(removed)
+	return err
 }
 
 // ConAckReceived will be called when the client receives a CONACK that indicates the connection has been successfully
@@ -151,14 +154,34 @@ func (s *State) Close() error {
 // others (we should not begin sending/receiving packets until after the CONACK has been processed).
 // TODO: Add errors() function so we can notify the client of errors whilst transmitting the session stuff?
 func (s *State) ConAckReceived(conn io.Writer, cp *packets.Connect, ca *packets.Connack) error {
+	s.mu.Lock()
+	removed, err := s.conAckReceived(conn, cp, ca)
+	if err != nil {
+		s.clearConnection()
+	}
+	s.mu.Unlock()
+	notifyRemoved(removed)
+	return err
+}
+
+// conAckReceived handles the transition of state caused by the receipt of CONNACK. Returns any packets removed
+// from state.
+// The caller must hold s.mu.
+func (s *State) conAckReceived(conn io.Writer, cp *packets.Connect, ca *packets.Connack) ([]clientGenerated, error) {
 	// We could use cp.Properties.SessionExpiryInterval /  ca.Properties.SessionExpiryInterval to clear the session
 	// after the specified time period (if the Session Expiry Interval is absent the value in the CONNECT Packet used)
-	// however, this is not something the generic client can really accomplish (forks may wish to do this!).
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	// however, this is not something the generic client can really achieve (forks may wish to do this!).
+	var removed []clientGenerated
+	if err := s.resetPendingStores(); err != nil {
+		return nil, fmt.Errorf("failed to complete pending session cleanup: %w", err)
+	}
 	if s.conn != nil {
 		s.errors.Println("ConAckReceived called whilst connection active (you MUST call ConnectionLost before starting a new connection")
-		_ = s.connectionLost(nil) // assume the connection dropped
+		var err error
+		removed, err = s.connectionLost(nil) // assume the connection dropped
+		if err != nil {
+			return removed, fmt.Errorf("failed to clean up previous connection: %w", err)
+		}
 	}
 	s.conn = conn
 	s.connCtx, s.connCtxCancel = context.WithCancel(context.Background())
@@ -170,7 +193,11 @@ func (s *State) ConAckReceived(conn io.Writer, cp *packets.Connect, ca *packets.
 	// packet. In both cases, it MUST set a 0x00 (Success) Reason Code in the CONNACK packet [MQTT-3.2.2-3].
 	if !ca.SessionPresent {
 		s.debug.Println("no session present - cleaning session state")
-		s.clean()
+		cleaned, err := s.clean()
+		removed = append(removed, cleaned...)
+		if err != nil {
+			return removed, fmt.Errorf("failed to clean session state: %w", err)
+		}
 	}
 	inFlight := uint16(len(s.clientPackets))
 	s.debug.Printf("%d inflight transactions upon connection", inFlight)
@@ -194,7 +221,7 @@ func (s *State) ConAckReceived(conn io.Writer, cp *packets.Connect, ca *packets.
 
 	if s.serverPackets == nil {
 		if err := s.loadServerSession(ca); err != nil {
-			return fmt.Errorf("failed to server session: %w", err)
+			return removed, fmt.Errorf("failed to load server session: %w", err)
 		}
 	}
 
@@ -209,7 +236,7 @@ func (s *State) ConAckReceived(conn io.Writer, cp *packets.Connect, ca *packets.
 	// the sending them before returning.
 	toResend, err := s.clientStore.List()
 	if err != nil {
-		return fmt.Errorf("failed to load stored message ids: %w", err)
+		return removed, fmt.Errorf("failed to load stored message ids: %w", err)
 	}
 	s.debug.Printf("retransmitting %d messages", len(toResend))
 	for _, id := range toResend {
@@ -254,25 +281,26 @@ func (s *State) ConAckReceived(conn io.Writer, cp *packets.Connect, ca *packets.
 		// Any failure from this point should result in loss of connection (so fatal)
 		if _, err := p.WriteTo(conn); err != nil {
 			s.debug.Printf("retransmitting of identifier %d failed: %s", id, err)
-			return fmt.Errorf("failed to retransmit message (%d): %w", id, err)
+			return removed, fmt.Errorf("failed to retransmit message (%d): %w", id, err)
 		}
 		s.debug.Printf("retransmitted message with identifier %d", id)
 		// On initial connection, the packet needs to be added to our record of client-generated packets.
 		if _, ok := s.clientPackets[id]; !ok {
+			response := make(chan packets.ControlPacket, 1)
 			s.clientPackets[id] = clientGenerated{
 				packetType:   p.Type,
-				responseChan: make(chan packets.ControlPacket, 1), // Nothing will wait on this
+				responseChan: response, // Nothing will wait on this
 			}
 		}
 	}
-	return nil
+	return removed, nil
 }
 
 // loadServerSession should be called once, when the first connection is established.
 // It loads the server session state from the store.
 // The caller must hold a lock on s.mu
 func (s *State) loadServerSession(ca *packets.Connack) error {
-	s.serverPackets = make(map[uint16]byte)
+	serverPackets := make(map[uint16]byte)
 	ids, err := s.serverStore.List()
 	if err != nil {
 		return fmt.Errorf("failed to load stored server message ids: %w", err)
@@ -283,7 +311,7 @@ func (s *State) loadServerSession(ca *packets.Connack) error {
 			s.errors.Printf("failed to load packet %d from server store: %s", id, err)
 			continue
 		}
-		// We only need to know the packet type so there is no need to process the entire packet
+		// We only need to know the packet type, so there is no need to process the entire packet
 		byte1 := make([]byte, 1)
 		_, err = r.Read(byte1)
 		_ = r.Close()
@@ -292,22 +320,23 @@ func (s *State) loadServerSession(ca *packets.Connack) error {
 				s.errors.Printf("failed to quarantine packet %d from server store (failed to read): %s", id, err)
 			}
 			s.errors.Printf("packet %d from server store could not be read: %s", id, err)
-			continue // don't want to fail so quarantine and continue is the best we can do
+			continue // don't want to fail, so quarantine and continue is the best we can do
 		}
 		packetType := byte1[0] >> 4
 		switch packetType {
 		case packets.PUBLISH:
-			s.serverPackets[id] = packets.PUBLISH
+			serverPackets[id] = packets.PUBLISH
 		case packets.PUBREC:
-			s.serverPackets[id] = packets.PUBREC
+			serverPackets[id] = packets.PUBREC
 		default:
 			if err := s.serverStore.Quarantine(id); err != nil {
 				s.errors.Printf("failed to quarantine packet %d from server store: %s", id, err)
 			}
 			s.errors.Printf("packet %d from server store had unexpected type %d", id, packetType)
-			continue // don't want to fail so quarantine and continue is the best we can do
+			continue // don't want to fail, so quarantine and continue is the best we can do
 		}
 	}
+	s.serverPackets = serverPackets
 	return nil
 }
 
@@ -315,19 +344,21 @@ func (s *State) loadServerSession(ca *packets.Connack) error {
 // to a network error (`nil` will be passed in)
 func (s *State) ConnectionLost(dp *packets.Disconnect) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.connectionLost(dp)
+	removed, err := s.connectionLost(dp)
+	s.mu.Unlock()
+	notifyRemoved(removed)
+	return err
 }
 
 // connectionLost process loss of connection
 // Caller MUST have locked c.Mu
-func (s *State) connectionLost(dp *packets.Disconnect) error {
+func (s *State) connectionLost(dp *packets.Disconnect) ([]clientGenerated, error) {
 	if s.conn == nil {
-		return nil // ConnectionLost may be called multiple times (but call ref Disconnect packet should be first)
+		// ConnectionLost may be called multiple times. A later call is also an opportunity to finish a store reset that
+		// failed while the connection was being torn down.
+		return nil, s.resetPendingStores()
 	}
-	s.connCtxCancel()
-	s.conn, s.connCtx, s.connCtxCancel = nil, nil, nil
-	s.connectionLostAt = time.Now()
+	s.clearConnection()
 
 	if dp != nil && dp.Properties != nil && dp.Properties.SessionExpiryInterval != nil {
 		s.sessionExpiryInterval = *dp.Properties.SessionExpiryInterval
@@ -336,25 +367,46 @@ func (s *State) connectionLost(dp *packets.Disconnect) error {
 	// Interval is greater than 0 [MQTT-3.1.2-23]
 	if s.sessionExpiryInterval == 0 {
 		s.debug.Println("sessionExpiryInterval is 0 and connection lost - cleaning session state")
-		s.clean()
+		return s.clean()
 	}
-	return nil
+	return s.tidy(), nil
+}
+
+// clearConnection marks the current network connection as unavailable. The old quota is retained while disconnected so
+// acknowledgements already read from that connection can safely unwind transactions. A successful CONNACK replaces it.
+// The caller must hold s.mu.
+func (s *State) clearConnection() {
+	if s.connCtxCancel != nil {
+		s.connCtxCancel()
+	}
+	s.conn, s.connCtx, s.connCtxCancel = nil, nil, nil
+	s.connectionLostAt = time.Now()
 }
 
 // AddToSession adds a packet to the session state (including allocation of a Message Identifier).
-// If this function returns a nil then:
+// If this function returns a nil error then:
 //   - A slot has been allocated if the packet is a PUBLISH (function will block if RECEIVE MAXIMUM messages are inflight)
 //   - A message Identifier has been added to the passed in packet
 //   - Publish messages will have been written to the store (and will be automatically transmitted if a new connection
 //     is established before the message is fully acknowledged - subject to state rules in the MQTTv5 spec)
-//   - Something will be sent to `resp` when either the message is fully acknowledged or the packet is removed from
-//     the session (in which case nil will be sent).
+//   - A state-owned response channel is returned. Exactly one value will be sent when either the message is fully
+//     acknowledged or the packet is removed from the session (in which case the zero value will be sent), after which
+//     the channel will be closed.
 //
-// If the function returns an error, then any actions taken will be rewound prior to return.
-func (s *State) AddToSession(ctx context.Context, packet session.Packet, resp chan<- packets.ControlPacket) error {
+// If the function returns an error, the response channel will be nil and any actions taken will be rewound prior to
+// return.
+func (s *State) AddToSession(ctx context.Context, packet session.Packet) (<-chan packets.ControlPacket, error) {
+	response := make(chan packets.ControlPacket, 1)
+	if err := s.addToSession(ctx, packet, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (s *State) addToSession(ctx context.Context, packet session.Packet, response chan<- packets.ControlPacket) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	s.mu.Lock() // There may be a delay waiting for semaphore so check for connection before and after
+	s.mu.Lock() // There may be a delay waiting for semaphore, so check for connection before and after
 	if s.conn == nil {
 		s.mu.Unlock()
 		return session.ErrNoConnection
@@ -365,11 +417,11 @@ func (s *State) AddToSession(ctx context.Context, packet session.Packet, resp ch
 	// replaced by ConAckReceived when a new connection is established. Take a
 	// reference to it here, under the mutex, rather than reading s.inflight later:
 	// Acquire may block, so it cannot be called while holding the mutex, and reading
-	// the field after unlocking races a reconnect replacing it.
+	// the field after unlocking races a reconnection replacing it.
 	inflight := s.inflight
 	s.mu.Unlock()
 
-	// If the connection drops while waiting we should abort
+	// If the connection drops while waiting, we should abort
 	go func() {
 		select {
 		case <-connCtx.Done():
@@ -390,13 +442,22 @@ func (s *State) AddToSession(ctx context.Context, packet session.Packet, resp ch
 		}
 	}
 
-	// We have a slot, so acquire a Message ID
-	// Need to look at what to do if this fails. Should be infrequent as:
-	//     its a lot of messages
-	//     receive max often defaults to a fairly low value
-	//     Maximum recieve max is 65535 which matches the number of slots (so would also need a SUB/UNSUB in flight).
-	packetID, err := s.allocateNextPacketId(pt, resp)
+	// We need the mutex again, so we recheck the connection as this may have been replaced.
+	s.mu.Lock()
+	if s.conn == nil || s.connCtx != connCtx {
+		s.mu.Unlock()
+		if pt == packets.PUBLISH {
+			if qErr := inflight.Release(); qErr != nil {
+				s.errors.Printf("quota release due to connection loss: %s", qErr)
+			}
+		}
+		return session.ErrNoConnection
+	}
+
+	// We have a slot, so acquire a Message ID (error on failure, there may be a better option?)
+	packetID, err := s.allocateNextPacketIdLocked(pt, response)
 	if err != nil {
+		s.mu.Unlock()
 		if pt == packets.PUBLISH {
 			if qErr := inflight.Release(); qErr != nil {
 				s.errors.Printf("quota release due to packet id issue: %s", qErr)
@@ -407,7 +468,6 @@ func (s *State) AddToSession(ctx context.Context, packet session.Packet, resp ch
 	packet.SetIdentifier(packetID)
 	if pt == packets.PUBLISH {
 		if err = s.clientStore.Put(packetID, pt, packet); err != nil {
-			s.mu.Lock()
 			delete(s.clientPackets, packetID)
 			s.mu.Unlock()
 			if qErr := inflight.Release(); qErr != nil {
@@ -417,6 +477,7 @@ func (s *State) AddToSession(ctx context.Context, packet session.Packet, resp ch
 			return err
 		}
 	}
+	s.mu.Unlock()
 	return nil
 }
 
@@ -426,12 +487,14 @@ func (s *State) endClientGenerated(packetID uint16, recv *packets.ControlPacket)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if cg, ok := s.clientPackets[packetID]; ok {
-		cg.responseChan <- *recv
+		complete(cg, *recv)
 		delete(s.clientPackets, packetID)
 		// Outgoing publish messages will be in the store (replaced with PUBREL that is sent)
 		if cg.packetType == packets.PUBLISH || cg.packetType == packets.PUBREL {
-			if qErr := s.inflight.Release(); qErr != nil {
-				s.errors.Printf("quota release due to %s: %s", recv.PacketType(), qErr)
+			if s.inflight != nil {
+				if qErr := s.inflight.Release(); qErr != nil {
+					s.errors.Printf("quota release due to %s: %s", recv.PacketType(), qErr)
+				}
 			}
 			if err := s.clientStore.Delete(packetID); err != nil {
 				s.errors.Printf("failed to remove message %d from store: %s", packetID, err)
@@ -531,17 +594,31 @@ func (s *State) PacketReceived(recv *packets.ControlPacket, pubChan chan<- *pack
 	case *packets.Pubrec: // Initial response to a QOS2 Publish
 		s.debug.Println("received PUBREC packet with id ", rp.PacketID)
 		s.mu.Lock()
-		_, ok := s.clientPackets[rp.PacketID]
+		cg, ok := s.clientPackets[rp.PacketID]
+		validTransaction := ok && (cg.packetType == packets.PUBLISH || cg.packetType == packets.PUBREL)
+		conn := s.conn
+		var storeErr error
+		if validTransaction && rp.ReasonCode < 0x80 {
+			pl := packets.Pubrel{PacketID: rp.PacketID}
+			storeErr = s.clientStore.Put(rp.PacketID, packets.PUBREL, &pl)
+			if storeErr == nil {
+				cg.packetType = packets.PUBREL
+				s.clientPackets[rp.PacketID] = cg
+			}
+		}
 		s.mu.Unlock()
-		if !ok {
+		if !validTransaction {
 			pl := packets.Pubrel{ // Respond with "Packet Identifier not found"
 				PacketID:   recv.Content.(*packets.Pubrec).PacketID,
 				ReasonCode: 0x92,
 			}
 			s.debug.Println("sending PUBREL (unknown ID) for ", pl.PacketID)
-			_, err := pl.WriteTo(s.conn)
-			if err != nil {
+			if conn == nil {
+				return session.ErrNoConnection
+			}
+			if _, err := pl.WriteTo(conn); err != nil {
 				s.errors.Printf("failed to send PUBREL for %d: %s", pl.PacketID, err)
+				return err
 			}
 		} else {
 			if rp.ReasonCode >= 0x80 {
@@ -551,12 +628,16 @@ func (s *State) PacketReceived(recv *packets.ControlPacket, pubChan chan<- *pack
 					PacketID: rp.PacketID,
 				}
 				s.debug.Println("sending PUBREL for", rp.PacketID)
-				// Update the store (we should never resend the PUBLISH after receiving a PUBREL)
-				if err := s.clientStore.Put(rp.PacketID, packets.PUBREL, &pl); err != nil {
-					s.errors.Printf("failed to write PUBREL to store for %d: %s", rp.PacketID, err)
+				if storeErr != nil {
+					s.errors.Printf("failed to write PUBREL to store for %d: %s", rp.PacketID, storeErr)
+					return storeErr
 				}
-				if _, err := pl.WriteTo(s.conn); err != nil {
+				if conn == nil {
+					return session.ErrNoConnection
+				}
+				if _, err := pl.WriteTo(conn); err != nil {
 					s.errors.Printf("failed to send PUBREL for %d: %s", rp.PacketID, err)
+					return err
 				}
 			}
 		}
@@ -639,13 +720,23 @@ func (s *State) PacketReceived(recv *packets.ControlPacket, pubChan chan<- *pack
 
 // allocateNextPacketId assigns the next available packet ID
 // Callers must NOT hold lock on s.mu
-func (s *State) allocateNextPacketId(forPacketType byte, resp chan<- packets.ControlPacket) (uint16, error) {
-	s.mu.Lock() // There may be a delay waiting for semaphore so check for connection before and after
+func (s *State) allocateNextPacketId(forPacketType byte) (uint16, <-chan packets.ControlPacket, error) {
+	response := make(chan packets.ControlPacket, 1)
+	s.mu.Lock()
 	defer s.mu.Unlock()
+	packetID, err := s.allocateNextPacketIdLocked(forPacketType, response)
+	if err != nil {
+		return 0, nil, err
+	}
+	return packetID, response, nil
+}
 
+// allocateNextPacketIdLocked assigns the next available packet ID.
+// The caller must hold s.mu.
+func (s *State) allocateNextPacketIdLocked(forPacketType byte, response chan<- packets.ControlPacket) (uint16, error) {
 	cg := clientGenerated{
 		packetType:   forPacketType,
-		responseChan: resp,
+		responseChan: response,
 	}
 
 	// Scan from lastMid to end of range.
@@ -676,19 +767,52 @@ func (s *State) allocateNextPacketId(forPacketType byte, resp chan<- packets.Con
 	return 0, session.ErrPacketIdentifiersExhausted
 }
 
-// clean deletes any existing stored session information
+// clean deletes any existing stored session information (returning the client packets removed)
 // does not touch inflight because this is not part of the session state (so is reset separately)
 // caller is responsible for locking s.mu
-func (s *State) clean() {
+func (s *State) clean() ([]clientGenerated, error) {
 	s.debug.Println("State.clean() called")
+	removed := make([]clientGenerated, 0, len(s.clientPackets))
+	for _, p := range s.clientPackets {
+		removed = append(removed, p)
+	}
 	s.serverPackets = make(map[uint16]byte)
 	s.clientPackets = make(map[uint16]clientGenerated)
 
-	s.serverStore.Reset()
-	s.clientStore.Reset()
+	// It's important that the stores are reset before another connection is accepted (otherwise we
+	// may transmit data we should not). As such we signal that this is needed and it's done at the
+	// start of `conAckReceived`. Note that it's possible that this info is lost across an application
+	// restart, but addressing that would require additional persistence (and is fairly unlikely).
+	s.serverStoreResetPending = true
+	s.clientStoreResetPending = true
+	return removed, s.resetPendingStores()
 }
 
-// clean deletes any existing stored session information
+// resetPendingStores completes any store cleanup required by a prior connection state change. A store remains
+// pending until Reset succeeds, and ConAckReceived will not load or retransmit session state while either store is pending.
+// The caller must hold s.mu.
+func (s *State) resetPendingStores() error {
+	var serverErr, clientErr error
+	if s.serverStoreResetPending {
+		if err := s.serverStore.Reset(); err != nil {
+			serverErr = fmt.Errorf("failed to reset server store: %w", err)
+		} else {
+			s.serverStoreResetPending = false
+		}
+	}
+	if s.clientStoreResetPending {
+		if err := s.clientStore.Reset(); err != nil {
+			clientErr = fmt.Errorf("failed to reset client store: %w", err)
+		} else {
+			s.clientStoreResetPending = false
+		}
+	}
+	return errors.Join(serverErr, clientErr)
+}
+
+// tidy removes transactions that are scoped to one network connection while
+// retaining the MQTT session state that should survive reconnection.
+// returns the packets that were removed.
 // as per section 4.1 in the spec; The Session State in the Client consists of:
 // > · QoS 1 and QoS 2 messages which have been sent to the Server, but have not been completely acknowledged.
 // > · QoS 2 messages which have been received from the Server, but have not been completely acknowledged.
@@ -697,7 +821,7 @@ func (s *State) clean() {
 // confirm if they have already been processed).
 // We only resend PUBLISH (where QoS > 0) and PUBREL packets (as per spec section 4.4)
 // caller is responsible for locking s.mu
-func (s *State) tidy(trigger *packets.ControlPacket) {
+func (s *State) tidy() []clientGenerated {
 	s.debug.Println("State.tidy() called")
 	for id, p := range s.serverPackets {
 		switch p {
@@ -707,18 +831,22 @@ func (s *State) tidy(trigger *packets.ControlPacket) {
 			// The broker will resend any `PUBLISH` and `PUBREL` messages, so there is no need to retain those.
 		default:
 			delete(s.serverPackets, id)
-			s.serverStore.Delete(id)
+			if err := s.serverStore.Delete(id); err != nil {
+				s.errors.Printf("failed to remove server packet %d while tidying session: %s", id, err)
+			}
 		}
 	}
 
+	var removed []clientGenerated
 	for id, p := range s.clientPackets {
-		// We only need to remember `PUBLISH` and `PUBREL` messages (both originating from a PUBLISH)
-		if p.packetType != packets.PUBLISH {
-			delete(s.clientPackets, id)
-			s.clientStore.Delete(id)
-			p.responseChan <- packets.ControlPacket{}
+		// We only need to remember PUBLISH and PUBREL messages (both originating from a PUBLISH).
+		if p.packetType == packets.PUBLISH || p.packetType == packets.PUBREL {
+			continue
 		}
+		delete(s.clientPackets, id)
+		removed = append(removed, p)
 	}
+	return removed
 }
 
 // SetDebugLogger takes an instance of the paho Logger interface
@@ -733,13 +861,20 @@ func (s *State) SetErrorLogger(l paholog.Logger) {
 	s.errors = l
 }
 
-// AllocateClientPacketIDForTest is intended for use in tests only. It allocates a packet ID in the client session state
-// This feels like a hack but makes it easier to test packet identifier exhaustion
-func (s *State) AllocateClientPacketIDForTest(packetID uint16, forPacketType byte, resp chan<- packets.ControlPacket) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.clientPackets[packetID] = clientGenerated{
-		packetType:   forPacketType,
-		responseChan: resp,
+// notifyRemoved releases callers whose transactions were discarded during a connection or session transition.
+// Notifications happen outside s.mu so a slow receiver cannot block all other state operations.
+func notifyRemoved(removed []clientGenerated) {
+	for _, p := range removed {
+		complete(p, packets.ControlPacket{})
 	}
+}
+
+// complete delivers the one response promised for a client-generated transaction. State-owned channels are buffered
+// and closed after the send; caller-owned channels retain the original SessionManager behavior.
+func complete(transaction clientGenerated, response packets.ControlPacket) {
+	if transaction.responseChan == nil {
+		return
+	}
+	transaction.responseChan <- response
+	close(transaction.responseChan)
 }

--- a/paho/session/state/state_connection_test.go
+++ b/paho/session/state/state_connection_test.go
@@ -1,0 +1,608 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ *  and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package state
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eclipse/paho.golang/packets"
+	"github.com/eclipse/paho.golang/paho/session"
+	"github.com/eclipse/paho.golang/paho/store/memory"
+)
+
+// state_connection_test
+// `state` manages MQTT sessions. These sessions may extend across many reconnections, so it's important that
+// changes to the connection are handled correctly (somewhat difficult due to concurrency).
+// The tests in this file replicate various situations where this could be handled badly.
+
+// pausedPublish allows a reconnection to be completed after AddToSession has
+// captured the current connection, but before it commits any session state.
+type pausedPublish struct {
+	packets.Publish
+	typeCalled chan struct{}
+	resume     chan struct{}
+}
+
+// Type is the first function called on the packet in AddToSession so represents a good place to pasue things
+func (p *pausedPublish) Type() byte {
+	close(p.typeCalled)
+	<-p.resume
+	return packets.PUBLISH
+}
+
+// TestAddToSessionDoesNotCrossConnections confirms correct handling of the sequence:
+//  1. Connection up
+//  2. Publish added to session
+//  3. Concurrently, reconnection completes (no active session)
+//  4. Publish processed
+//
+// In this situation ErrNoConnection should be returned because the initial connection was lost (this leaves it up to
+// our user to re-send)
+func TestAddToSessionDoesNotCrossConnections(t *testing.T) {
+	s := NewInMemory()
+	t.Cleanup(func() { _ = s.Close() })
+
+	connect := &packets.Connect{}
+	connack := &packets.Connack{ReasonCode: 0, SessionPresent: false}
+	if err := s.ConAckReceived(io.Discard, connect, connack); err != nil {
+		t.Fatalf("initial ConAckReceived: %v", err)
+	}
+
+	publish := &pausedPublish{
+		Publish: packets.Publish{
+			QoS:        1,
+			Topic:      "connection/epoch",
+			Properties: &packets.Properties{},
+		},
+		typeCalled: make(chan struct{}),
+		resume:     make(chan struct{}),
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := s.AddToSession(context.Background(), publish)
+		result <- err
+	}()
+
+	<-publish.typeCalled
+	if err := s.ConnectionLost(nil); err != nil {
+		t.Fatalf("ConnectionLost: %v", err)
+	}
+	if err := s.ConAckReceived(io.Discard, connect, connack); err != nil {
+		t.Fatalf("second ConAckReceived: %v", err)
+	}
+	close(publish.resume)
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, session.ErrNoConnection) {
+			t.Fatalf("AddToSession returned %v; want ErrNoConnection", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AddToSession did not return")
+	}
+	if publish.PacketID != 0 {
+		t.Fatalf("AddToSession allocated packet ID %d on the replacement connection", publish.PacketID)
+	}
+	ids, err := s.clientStore.List()
+	if err != nil {
+		t.Fatalf("listing client store: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("AddToSession stored packet IDs %v on the replacement connection", ids)
+	}
+}
+
+// TestPubrecResponseWhileConnectionChanges continually changes the connection used by State whilst simulating the
+// receipt of packets. This is intended to be run with the race detector.
+func TestPubrecResponseWhileConnectionChanges(t *testing.T) {
+	s := NewInMemory()
+	t.Cleanup(func() { _ = s.Close() })
+
+	connect := &packets.Connect{}
+	connack := &packets.Connack{ReasonCode: 0, SessionPresent: false}
+	if err := s.ConAckReceived(io.Discard, connect, connack); err != nil {
+		t.Fatalf("initial ConAckReceived: %v", err)
+	}
+
+	recv := packets.NewControlPacket(packets.PUBREC)
+	recv.Content.(*packets.Pubrec).PacketID = 1 // Unknown ID uses the immediate PUBREL response path.
+
+	const rounds = 200
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range rounds {
+			if err := s.ConnectionLost(nil); err != nil {
+				t.Errorf("ConnectionLost: %v", err)
+				return
+			}
+			if err := s.ConAckReceived(io.Discard, connect, connack); err != nil {
+				t.Errorf("ConAckReceived: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range rounds {
+			_ = s.PacketReceived(recv, nil) //pubChan not needed as no PUBLISH sent
+		}
+	}()
+	close(start)
+	wg.Wait()
+}
+
+// TestConnectionLostRemovesNonSessionTransactions SUBSCRIBE packets are not part of the session state (completed
+// subscriptions are, but that's for the broker to handle). This checks that these packets are removed from the state
+// following a reconnection.
+func TestConnectionLostRemovesNonSessionTransactions(t *testing.T) {
+	s := NewInMemory()
+	t.Cleanup(func() { _ = s.Close() })
+
+	expiry := uint32(60)
+	connect := &packets.Connect{Properties: &packets.Properties{SessionExpiryInterval: &expiry}}
+	if err := s.ConAckReceived(io.Discard, connect, &packets.Connack{}); err != nil {
+		t.Fatalf("ConAckReceived: %v", err)
+	}
+
+	subscribe := &packets.Subscribe{Properties: &packets.Properties{}}
+	response, err := s.AddToSession(context.Background(), subscribe)
+	if err != nil {
+		t.Fatalf("AddToSession: %v", err)
+	}
+	if err := s.ConnectionLost(nil); err != nil {
+		t.Fatalf("ConnectionLost: %v", err)
+	}
+
+	s.mu.Lock()
+	_, exists := s.clientPackets[subscribe.PacketID]
+	s.mu.Unlock()
+	if exists {
+		t.Fatal("SUBSCRIBE packet ID retained after connection loss")
+	}
+	select {
+	case <-response:
+	default:
+		t.Fatal("SUBSCRIBE waiter was not notified of connection loss")
+	}
+}
+
+// TestConnectionLostNotifiesCleanedTransactions when a transaction is terminated due to a reconnection, some
+// packets may be removed from the state. The user may be waiting on these, so we need to notify them.
+func TestConnectionLostNotifiesCleanedTransactions(t *testing.T) {
+	s := NewInMemory()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.ConAckReceived(io.Discard, &packets.Connect{}, &packets.Connack{}); err != nil {
+		t.Fatalf("ConAckReceived: %v", err)
+	}
+	publish := &packets.Publish{QoS: 1, Topic: "clean/session", Properties: &packets.Properties{}}
+	response, err := s.AddToSession(context.Background(), publish)
+	if err != nil {
+		t.Fatalf("AddToSession: %v", err)
+	}
+	if err := s.ConnectionLost(nil); err != nil {
+		t.Fatalf("ConnectionLost: %v", err)
+	}
+
+	select {
+	case <-response:
+	default:
+		t.Fatal("PUBLISH waiter was not notified when its session state was deleted")
+	}
+}
+
+// TestConnectionLostRetainsSessionTransactions confirms that a PUBREC is retained when the connection is lost.
+func TestConnectionLostRetainsSessionTransactions(t *testing.T) {
+	s := NewInMemory()
+	t.Cleanup(func() { _ = s.Close() })
+
+	expiry := uint32(60)
+	connect := &packets.Connect{Properties: &packets.Properties{SessionExpiryInterval: &expiry}}
+	if err := s.ConAckReceived(io.Discard, connect, &packets.Connack{}); err != nil {
+		t.Fatalf("ConAckReceived: %v", err)
+	}
+
+	publish := &packets.Publish{QoS: 2, Topic: "persistent/session", Properties: &packets.Properties{}}
+	response, err := s.AddToSession(context.Background(), publish)
+	if err != nil {
+		t.Fatalf("AddToSession: %v", err)
+	}
+	pubrec := packets.NewControlPacket(packets.PUBREC)
+	pubrec.Content.(*packets.Pubrec).PacketID = publish.PacketID
+	if err := s.PacketReceived(pubrec, nil); err != nil {
+		t.Fatalf("PacketReceived: %v", err)
+	}
+	if err := s.ConnectionLost(nil); err != nil {
+		t.Fatalf("ConnectionLost: %v", err)
+	}
+
+	s.mu.Lock()
+	transaction, exists := s.clientPackets[publish.PacketID]
+	s.mu.Unlock()
+	if !exists {
+		t.Fatal("QoS 2 transaction was removed from a persistent session")
+	}
+	if transaction.packetType != packets.PUBREL {
+		t.Fatalf("retained transaction type is %d; want PUBREL", transaction.packetType)
+	}
+	select {
+	case <-response:
+		t.Fatal("persistent QoS 2 waiter was notified before the transaction completed")
+	default:
+	}
+}
+
+type listFailStore struct{ *memory.Store }
+
+func (s *listFailStore) List() ([]uint16, error) {
+	return nil, errors.New("injected List failure")
+}
+
+type controlledListStore struct {
+	*memory.Store
+	fail bool
+}
+
+func (s *controlledListStore) List() ([]uint16, error) {
+	if s.fail {
+		return nil, errors.New("injected List failure")
+	}
+	return s.Store.List()
+}
+
+type putFailStore struct{ *memory.Store }
+
+func (s *putFailStore) Put(uint16, byte, io.WriterTo) error {
+	return errors.New("injected Put failure")
+}
+
+type resetFailStore struct {
+	*memory.Store
+	resetFailures int
+	resetCalls    int
+}
+
+func (s *resetFailStore) Reset() error {
+	s.resetCalls++
+	if s.resetFailures > 0 {
+		s.resetFailures--
+		return errors.New("injected Reset failure")
+	}
+	return s.Store.Reset()
+}
+
+// TestPendingStoreResetBlocksStaleRetransmission confirms that transactions discarded with a broker session are not
+// resurrected if the physical store reset initially fails. Only failed stores should be retried.
+func TestPendingStoreResetBlocksStaleRetransmission(t *testing.T) {
+	clientStore := &resetFailStore{Store: memory.New()}
+	serverStore := &resetFailStore{Store: memory.New()}
+	s := New(clientStore, serverStore)
+	t.Cleanup(func() { _ = s.Close() })
+
+	expiry := uint32(60)
+	connect := &packets.Connect{Properties: &packets.Properties{SessionExpiryInterval: &expiry}}
+	if err := s.ConAckReceived(io.Discard, connect, &packets.Connack{SessionPresent: true}); err != nil {
+		t.Fatalf("initial ConAckReceived: %v", err)
+	}
+	publish := &packets.Publish{QoS: 1, Topic: "stale/session", Properties: &packets.Properties{}}
+	response, err := s.AddToSession(context.Background(), publish)
+	if err != nil {
+		t.Fatalf("AddToSession: %v", err)
+	}
+	if err := s.ConnectionLost(nil); err != nil {
+		t.Fatalf("ConnectionLost: %v", err)
+	}
+
+	clientStore.resetFailures = 2
+	if err := s.ConAckReceived(io.Discard, connect, &packets.Connack{SessionPresent: false}); err == nil {
+		t.Fatal("expected session cleanup to fail")
+	}
+	if removed, ok := <-response; !ok || removed.Type != 0 {
+		t.Fatalf("removed response is type %d, open=%t; want zero value", removed.Type, ok)
+	}
+	if _, ok := <-response; ok {
+		t.Fatal("response channel was not closed after the transaction was removed")
+	}
+	if clientStore.resetCalls != 1 || serverStore.resetCalls != 1 {
+		t.Fatalf("initial reset calls: client=%d server=%d; want 1 each", clientStore.resetCalls, serverStore.resetCalls)
+	}
+
+	var retransmitted bytes.Buffer
+	if err := s.ConAckReceived(&retransmitted, connect, &packets.Connack{SessionPresent: true}); err == nil {
+		t.Fatal("expected connection to fail while client-store cleanup is still pending")
+	}
+	if retransmitted.Len() != 0 {
+		t.Fatalf("wrote %d stale packet bytes while cleanup was pending", retransmitted.Len())
+	}
+	if clientStore.resetCalls != 2 || serverStore.resetCalls != 1 {
+		t.Fatalf("pending reset calls: client=%d server=%d; want client=2 server=1", clientStore.resetCalls, serverStore.resetCalls)
+	}
+
+	if err := s.ConAckReceived(&retransmitted, connect, &packets.Connack{SessionPresent: true}); err != nil {
+		t.Fatalf("ConAckReceived after cleanup succeeded: %v", err)
+	}
+	if retransmitted.Len() != 0 {
+		t.Fatalf("retransmitted %d stale packet bytes after cleanup", retransmitted.Len())
+	}
+	if clientStore.resetCalls != 3 || serverStore.resetCalls != 1 {
+		t.Fatalf("final reset calls: client=%d server=%d; want client=3 server=1", clientStore.resetCalls, serverStore.resetCalls)
+	}
+	ids, err := clientStore.List()
+	if err != nil {
+		t.Fatalf("listing client store: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("client store retained stale packet IDs %v", ids)
+	}
+
+	s.mu.Lock()
+	clientPending := s.clientStoreResetPending
+	serverPending := s.serverStoreResetPending
+	s.mu.Unlock()
+	if clientPending || serverPending {
+		t.Fatalf("reset flags remain pending: client=%t server=%t", clientPending, serverPending)
+	}
+}
+
+// TestAddToSessionReturnsNilChannelOnStoreFailure confirms that a response channel is only exposed after the packet has
+// been fully accepted into the session.
+func TestAddToSessionReturnsNilChannelOnStoreFailure(t *testing.T) {
+	s := New(&putFailStore{Store: memory.New()}, memory.New())
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.ConAckReceived(io.Discard, &packets.Connect{}, &packets.Connack{}); err != nil {
+		t.Fatalf("ConAckReceived: %v", err)
+	}
+	publish := &packets.Publish{QoS: 1, Topic: "store/failure", Properties: &packets.Properties{}}
+	response, err := s.AddToSession(context.Background(), publish)
+	if err == nil {
+		t.Fatal("AddToSession succeeded despite the store failure")
+	}
+	if response != nil {
+		t.Fatal("AddToSession returned a response channel after the store failure")
+	}
+	if publish.PacketID != 0 {
+		t.Fatalf("AddToSession left packet ID %d assigned after the store failure", publish.PacketID)
+	}
+}
+
+// TestConAckFailureRollsBackConnectionState if we are unable to access our persisted store upon receipt of a CONNACK
+// then what should we actually do???
+func TestConAckFailureRollsBackConnectionState(t *testing.T) {
+	s := New(&listFailStore{Store: memory.New()}, memory.New())
+	t.Cleanup(func() { _ = s.Close() })
+
+	err := s.ConAckReceived(io.Discard, &packets.Connect{}, &packets.Connack{})
+	if err == nil {
+		t.Fatal("expected ConAckReceived to fail")
+	}
+
+	s.mu.Lock()
+	connected := s.conn != nil || s.connCtx != nil || s.connCtxCancel != nil
+	s.mu.Unlock()
+	if connected {
+		t.Fatal("failed ConAckReceived left the session marked connected")
+	}
+
+	publish := &packets.Publish{QoS: 1}
+	response, err := s.AddToSession(context.Background(), publish)
+	if !errors.Is(err, session.ErrNoConnection) {
+		t.Fatalf("AddToSession after failed CONNACK returned %v; want ErrNoConnection", err)
+	}
+	if response != nil {
+		t.Fatal("AddToSession returned a response channel after failing")
+	}
+}
+
+// TestAckAfterFailedConAck confirms that a retained transaction can still be completed after CONNACK processing fails.
+// The failed connection's quota is intentionally left available for acknowledgements already read from the connection.
+func TestAckAfterFailedConAck(t *testing.T) {
+	clientStore := &controlledListStore{Store: memory.New()}
+	s := New(clientStore, memory.New())
+	t.Cleanup(func() { _ = s.Close() })
+
+	expiry := uint32(60)
+	connect := &packets.Connect{Properties: &packets.Properties{SessionExpiryInterval: &expiry}}
+	if err := s.ConAckReceived(io.Discard, connect, &packets.Connack{SessionPresent: true}); err != nil {
+		t.Fatalf("initial ConAckReceived: %v", err)
+	}
+	publish := &packets.Publish{QoS: 1, Topic: "failed/connack", Properties: &packets.Properties{}}
+	response, err := s.AddToSession(context.Background(), publish)
+	if err != nil {
+		t.Fatalf("AddToSessionWithResponse: %v", err)
+	}
+	if err := s.ConnectionLost(nil); err != nil {
+		t.Fatalf("ConnectionLost: %v", err)
+	}
+
+	clientStore.fail = true
+	if err := s.ConAckReceived(io.Discard, connect, &packets.Connack{SessionPresent: true}); err == nil {
+		t.Fatal("expected ConAckReceived to fail")
+	}
+	clientStore.fail = false
+
+	ack := packets.NewControlPacket(packets.PUBACK)
+	ack.Content.(*packets.Puback).PacketID = publish.PacketID
+	if err := s.PacketReceived(ack, nil); err != nil {
+		t.Fatalf("PacketReceived: %v", err)
+	}
+	if got, ok := <-response; !ok || got.Type != packets.PUBACK {
+		t.Fatalf("response is type %d, open=%t; want PUBACK", got.Type, ok)
+	}
+	ids, err := clientStore.List()
+	if err != nil {
+		t.Fatalf("listing client store: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("completed packet remains in client store: %v", ids)
+	}
+}
+
+// TestPubrecDoesNotAdvanceNonPublishTransaction confirms that a stray PUBREC cannot turn a SUBSCRIBE into a retained
+// QoS 2 transaction.
+func TestPubrecDoesNotAdvanceNonPublishTransaction(t *testing.T) {
+	s := NewInMemory()
+	t.Cleanup(func() { _ = s.Close() })
+
+	expiry := uint32(60)
+	connect := &packets.Connect{Properties: &packets.Properties{SessionExpiryInterval: &expiry}}
+	var written bytes.Buffer
+	if err := s.ConAckReceived(&written, connect, &packets.Connack{}); err != nil {
+		t.Fatalf("ConAckReceived: %v", err)
+	}
+	subscribe := &packets.Subscribe{Properties: &packets.Properties{}}
+	response, err := s.AddToSession(context.Background(), subscribe)
+	if err != nil {
+		t.Fatalf("AddToSessionWithResponse: %v", err)
+	}
+
+	pubrec := packets.NewControlPacket(packets.PUBREC)
+	pubrec.Content.(*packets.Pubrec).PacketID = subscribe.PacketID
+	if err := s.PacketReceived(pubrec, nil); err != nil {
+		t.Fatalf("PacketReceived: %v", err)
+	}
+
+	s.mu.Lock()
+	transaction, exists := s.clientPackets[subscribe.PacketID]
+	s.mu.Unlock()
+	if !exists || transaction.packetType != packets.SUBSCRIBE {
+		t.Fatalf("transaction after PUBREC: exists=%t type=%d; want SUBSCRIBE", exists, transaction.packetType)
+	}
+	ids, err := s.clientStore.List()
+	if err != nil {
+		t.Fatalf("listing client store: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("stray PUBREC wrote client-store entries %v", ids)
+	}
+	writtenPacket, err := packets.ReadPacket(&written)
+	if err != nil {
+		t.Fatalf("reading PUBREL response: %v", err)
+	}
+	pubrel, ok := writtenPacket.Content.(*packets.Pubrel)
+	if !ok || pubrel.PacketID != subscribe.PacketID || pubrel.ReasonCode != 0x92 {
+		t.Fatalf("response is %#v; want PUBREL reason 0x92 for packet %d", writtenPacket.Content, subscribe.PacketID)
+	}
+
+	if err := s.ConnectionLost(nil); err != nil {
+		t.Fatalf("ConnectionLost: %v", err)
+	}
+	if got, ok := <-response; !ok || got.Type != 0 {
+		t.Fatalf("removed response is type %d, open=%t; want zero value", got.Type, ok)
+	}
+}
+
+// TestAddToSessionOwnsResponseChannel confirms that every accepted transaction gets a distinct, buffered, one-shot
+// response channel owned by State.
+func TestAddToSessionOwnsResponseChannel(t *testing.T) {
+	s := NewInMemory()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.ConAckReceived(io.Discard, &packets.Connect{}, &packets.Connack{}); err != nil {
+		t.Fatalf("ConAckReceived: %v", err)
+	}
+	first := &packets.Subscribe{Properties: &packets.Properties{}}
+	firstResponse, err := s.AddToSession(context.Background(), first)
+	if err != nil {
+		t.Fatalf("first AddToSession: %v", err)
+	}
+	second := &packets.Subscribe{Properties: &packets.Properties{}}
+	secondResponse, err := s.AddToSession(context.Background(), second)
+	if err != nil {
+		t.Fatalf("second AddToSession: %v", err)
+	}
+	if firstResponse == secondResponse {
+		t.Fatal("AddToSession reused a response channel")
+	}
+	if cap(firstResponse) != 1 || cap(secondResponse) != 1 {
+		t.Fatalf("response channel capacities are %d and %d; want 1", cap(firstResponse), cap(secondResponse))
+	}
+
+	ack := packets.NewControlPacket(packets.SUBACK)
+	ack.Content.(*packets.Suback).PacketID = first.PacketID
+	if err := s.PacketReceived(ack, nil); err != nil {
+		t.Fatalf("PacketReceived: %v", err)
+	}
+	if response, ok := <-firstResponse; !ok || response.Type != packets.SUBACK {
+		t.Fatalf("first response is type %d, open=%t; want SUBACK on an open channel", response.Type, ok)
+	}
+	if _, ok := <-firstResponse; ok {
+		t.Fatal("first response channel was not closed after its response")
+	}
+
+	if err := s.ConnectionLost(nil); err != nil {
+		t.Fatalf("ConnectionLost: %v", err)
+	}
+	if response, ok := <-secondResponse; !ok || response.Type != 0 {
+		t.Fatalf("removed response is type %d, open=%t; want zero value on an open channel", response.Type, ok)
+	}
+	if _, ok := <-secondResponse; ok {
+		t.Fatal("second response channel was not closed after removal")
+	}
+}
+
+// listFailOnceStore fails on the first attempt to call `List`, subsequent attempts succeed.
+type listFailOnceStore struct {
+	*memory.Store
+	failed bool
+}
+
+func (s *listFailOnceStore) List() ([]uint16, error) {
+	if !s.failed {
+		s.failed = true
+		return nil, errors.New("injected first List failure")
+	}
+	return s.Store.List()
+}
+
+// TestConAckRetriesServerStoreAfterFailure checks that intermittent failures of store.List() are handled
+func TestConAckRetriesServerStoreAfterFailure(t *testing.T) {
+	serverStore := &listFailOnceStore{Store: memory.New()}
+	stored := packets.NewControlPacket(packets.PUBREC)
+	stored.Content.(*packets.Pubrec).PacketID = 7
+	if err := serverStore.Put(7, packets.PUBREC, stored); err != nil {
+		t.Fatalf("seeding server store: %v", err)
+	}
+	s := New(memory.New(), serverStore)
+	t.Cleanup(func() { _ = s.Close() })
+
+	connect := &packets.Connect{}
+	connack := &packets.Connack{SessionPresent: true}
+	if err := s.ConAckReceived(io.Discard, connect, connack); err == nil {
+		t.Fatal("expected first ConAckReceived to fail")
+	}
+	if err := s.ConAckReceived(io.Discard, connect, connack); err != nil {
+		t.Fatalf("second ConAckReceived: %v", err)
+	}
+
+	s.mu.Lock()
+	packetType, exists := s.serverPackets[7]
+	s.mu.Unlock()
+	if !exists || packetType != packets.PUBREC {
+		t.Fatalf("server session was not reloaded after retry: type=%d exists=%t", packetType, exists)
+	}
+}

--- a/paho/session/state/state_race_test.go
+++ b/paho/session/state/state_race_test.go
@@ -74,11 +74,10 @@ func TestAddToSessionWhileReconnecting(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		resp := make(chan packets.ControlPacket, 1)
 		for range rounds {
 			pub := packets.NewControlPacket(packets.PUBLISH)
 			pub.Content.(*packets.Publish).QoS = 1
-			err := s.AddToSession(context.Background(), pub.Content.(*packets.Publish), resp)
+			_, err := s.AddToSession(context.Background(), pub.Content.(*packets.Publish))
 			if err != nil && err != session.ErrNoConnection {
 				// Anything else is a real failure; a lost connection is the
 				// expected outcome of racing a disconnect.


### PR DESCRIPTION
When looking at PR #341 I identified some other correctness issues with the state handling. Issue #343 covers most of these, including the `tidy` function that was written but never called.

This PR aims to address the issues covered in #343 and address previous oversights. There is one potential breaking change in that the signature of `SessionManager.AddToSession` changes. I doubt anyone has written their own implementation so this should have minimal impact (and I think it's important to clarify ownership of the channel).

Includes a number of Codex generated tests to better exercise the state management.

OpenAI Codex (GPT-5) assisted with code review, implementation. I have carefully reviewed the resulting changes and run tests manually.

closes #343
