### PR TITLE
Fix file queue/store ordering on coarse-ModTime filesystems

### DIFF
--- a/autopaho/queue/file/queue.go
+++ b/autopaho/queue/file/queue.go
@@ -49,12 +49,16 @@ type Queue struct {
 	queueEmpty      bool              // true is the queue is currently empty
 	waiting         []chan<- struct{} // closed when something arrives in the queue
 	waitingForEmpty []chan<- struct{} // closed when queue is empty
+	lastOrderTime   time.Time         // last ModTime handed out by nextOrderTime (see that function for details)
 }
 
 // New creates a new file-based queue. Note that a file is written, read and deleted as part of this process to check
 // that the path is usable.
-// NOTE: Order is maintained using file ModTime, so there may be issues if the interval between messages is less than
-// the file system ModTime resolution.
+// NOTE: Order is maintained using file ModTime. This is set explicitly, using a monotonically increasing clock
+// (rather than relying upon the value automatically applied by the OS when the file is written), because some
+// platforms/filesystems only update ModTime with a coarse resolution meaning files written in rapid succession
+// could otherwise end up with an identical ModTime and be retrieved out of order (see
+// https://github.com/eclipse-paho/paho.golang/issues/342).
 func New(path string, prefix string, extension string) (*Queue, error) {
 	if len(extension) > 0 && extension[0] != '.' {
 		extension = "." + extension
@@ -172,7 +176,26 @@ func (q *Queue) put(p io.Reader) error {
 		_ = os.Remove(f.Name()) // Attempt to remove the partial file (not much we can do if this fails)
 		return err
 	}
+
+	// Explicitly stamp the ModTime using our own monotonically increasing clock (see nextOrderTime and the
+	// comment on New for why this is necessary). This is best-effort; if it fails the entry has still been
+	// safely written so there is no need to fail the whole operation (ordering may just be less reliable).
+	_ = os.Chtimes(f.Name(), time.Now(), q.nextOrderTime())
 	return nil
+}
+
+// nextOrderTime returns a time.Time that is guaranteed to be strictly later than any time previously returned by
+// this method on this Queue. It is used to stamp the ModTime of queue files so entries can always be retrieved in
+// the order they were enqueued, even on filesystems/platforms where ModTime is only updated with a coarse
+// resolution (which could otherwise cause files written in rapid succession to share an identical ModTime).
+// Caller must hold q.mu.
+func (q *Queue) nextOrderTime() time.Time {
+	t := time.Now()
+	if !t.After(q.lastOrderTime) {
+		t = q.lastOrderTime.Add(time.Nanosecond)
+	}
+	q.lastOrderTime = t
+	return t
 }
 
 // get() returns a ReadCloser that accesses the oldest file available

--- a/autopaho/queue/file/queue_test.go
+++ b/autopaho/queue/file/queue_test.go
@@ -101,6 +101,69 @@ func TestFileQueue(t *testing.T) {
 	}
 }
 
+// TestFileQueueOrderWithCoarseModTime is a regression test for
+// https://github.com/eclipse-paho/paho.golang/issues/342 - some platforms/filesystems only update a file's
+// ModTime with a coarse resolution, so files written in rapid succession can end up sharing an identical
+// ModTime. If that happens ordering must still be correct, so this test enqueues a batch of entries with no
+// delay between them (unlike TestFileQueue, which sleeps between each Enqueue) and confirms Peek/Remove still
+// returns them in the order they were enqueued.
+func TestFileQueueOrderWithCoarseModTime(t *testing.T) {
+	q, err := New(t.TempDir(), "queueOrderTest-", ".que")
+	if err != nil {
+		t.Fatalf("failed to create queue: %s", err)
+	}
+
+	const entryFormat = "Queue entry %d for ordering test"
+	const count = 50
+	for i := 0; i < count; i++ {
+		if err := q.Enqueue(bytes.NewReader([]byte(fmt.Sprintf(entryFormat, i)))); err != nil {
+			t.Fatalf("error adding entry %d: %s", i, err)
+		}
+	}
+
+	for i := 0; i < count; i++ {
+		entry, err := q.Peek()
+		if err != nil {
+			t.Fatalf("error peeking entry %d: %s", i, err)
+		}
+		r, err := entry.Reader()
+		if err != nil {
+			t.Fatalf("error getting reader for entry %d: %s", i, err)
+		}
+		buf := &bytes.Buffer{}
+		if _, err = buf.ReadFrom(r); err != nil {
+			t.Fatalf("error reading entry %d: %s", i, err)
+		}
+		if err = entry.Remove(); err != nil {
+			t.Fatalf("error removing queue entry %d: %s", i, err)
+		}
+
+		expected := []byte(fmt.Sprintf(entryFormat, i))
+		if bytes.Compare(expected, buf.Bytes()) != 0 {
+			t.Fatalf("expected \"%s\", got \"%s\"", expected, buf.Bytes())
+		}
+	}
+
+	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
+		t.Errorf("expected ErrEmpty, got %s", err)
+	}
+}
+
+// TestNextOrderTimeMonotonic confirms that nextOrderTime always returns strictly increasing values, even when
+// called in a tight loop (i.e. faster than time.Now() itself may change) - this is what guarantees queue
+// ordering is correct regardless of the OS/filesystem's ModTime resolution.
+func TestNextOrderTimeMonotonic(t *testing.T) {
+	q := &Queue{}
+	prev := q.nextOrderTime()
+	for i := 0; i < 10000; i++ {
+		next := q.nextOrderTime()
+		if !next.After(prev) {
+			t.Fatalf("nextOrderTime did not increase: prev=%s, next=%s", prev, next)
+		}
+		prev = next
+	}
+}
+
 // TestLeaveAndError checks that the Leave and Error functions do what is expected
 func TestLeaveAndError(t *testing.T) {
 	testDirectory := t.TempDir()

--- a/paho/store/file/store.go
+++ b/paho/store/file/store.go
@@ -35,8 +35,11 @@ const (
 
 // New creates a file Store. Note that a file is written, read and deleted as part of this process to check that the
 // path is usable.
-// NOTE: Order is maintained using file ModTime, so there may be issues if the interval between messages is less than
-// the file system ModTime resolution.
+// NOTE: Order is maintained using file ModTime. This is set explicitly, using a monotonically increasing clock
+// (rather than relying upon the value automatically applied by the OS when the file is written), because some
+// platforms/filesystems only update ModTime with a coarse resolution meaning files written in rapid succession
+// could otherwise end up with an identical ModTime and be listed out of order (see
+// https://github.com/eclipse-paho/paho.golang/issues/342).
 func New(path string, prefix string, extension string) (*Store, error) {
 	if len(extension) > 0 && extension[0] != '.' {
 		extension = "." + extension
@@ -73,6 +76,8 @@ type Store struct {
 	path       string
 	prefix     string
 	extension  string
+
+	lastOrderTime time.Time // last ModTime handed out by nextOrderTime (see that function for details)
 }
 
 // Put stores the packet
@@ -101,7 +106,26 @@ func (s *Store) Put(packetID uint16, packetType byte, w io.WriterTo) error {
 		_ = os.Remove(tmpFn)
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
+
+	// Explicitly stamp the ModTime using our own monotonically increasing clock (see nextOrderTime and the
+	// comment on New for why this is necessary). This is best-effort; if it fails the packet has still been
+	// safely stored so there is no need to fail the whole operation (ordering may just be less reliable).
+	_ = os.Chtimes(s.filePathForId(packetID), time.Now(), s.nextOrderTime())
 	return nil
+}
+
+// nextOrderTime returns a time.Time that is guaranteed to be strictly later than any time previously returned by
+// this method on this Store. It is used to stamp the ModTime of stored packet files so List can always return
+// packet IDs in the order they were Put, even on filesystems/platforms where ModTime is only updated with a
+// coarse resolution (which could otherwise cause files written in rapid succession to share an identical
+// ModTime). Caller must hold the Store's mutex.
+func (s *Store) nextOrderTime() time.Time {
+	t := time.Now()
+	if !t.After(s.lastOrderTime) {
+		t = s.lastOrderTime.Add(time.Nanosecond)
+	}
+	s.lastOrderTime = t
+	return t
 }
 
 // Get retrieves the requested packet

--- a/paho/store/file/store_test.go
+++ b/paho/store/file/store_test.go
@@ -148,6 +148,63 @@ func TestFileStoreNaming(t *testing.T) {
 
 }
 
+// TestFileStoreListOrderWithCoarseModTime is a regression test for
+// https://github.com/eclipse-paho/paho.golang/issues/342 - some platforms/filesystems only update a file's
+// ModTime with a coarse resolution, so files Put in rapid succession can end up sharing an identical ModTime.
+// If that happens List must still return packet IDs in Put order, so this test Puts a batch of packets with no
+// delay between them and confirms List preserves that order.
+func TestFileStoreListOrderWithCoarseModTime(t *testing.T) {
+	t.Parallel()
+	s, err := New(t.TempDir(), "orderTest", ".ext")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const count = 100
+	ids := make([]uint16, count)
+	for i := 0; i < count; i++ {
+		id := uint16(i + 1)
+		ids[i] = id
+		pcp := packets.NewControlPacket(packets.PUBLISH)
+		pcp.Content.(*packets.Publish).PacketID = id
+		pcp.Content.(*packets.Publish).QoS = 1
+		pcp.Content.(*packets.Publish).Payload = []byte(fmt.Sprintf("%d", id))
+
+		if err := s.Put(id, packets.PUBLISH, pcp); err != nil {
+			t.Fatalf("failed to put %d: %s", id, err)
+		}
+	}
+
+	rids, err := s.List()
+	if err != nil {
+		t.Fatalf("failed to list: %s", err)
+	}
+	if len(rids) != len(ids) {
+		t.Fatalf("List returned %d elements, expected %d", len(rids), len(ids))
+	}
+	for i, v := range rids {
+		if v != ids[i] {
+			t.Fatalf("List returned %v, expected %v", rids, ids)
+		}
+	}
+}
+
+// TestFileStoreNextOrderTimeMonotonic confirms that nextOrderTime always returns strictly increasing values,
+// even when called in a tight loop (i.e. faster than time.Now() itself may change) - this is what guarantees
+// List ordering is correct regardless of the OS/filesystem's ModTime resolution.
+func TestFileStoreNextOrderTimeMonotonic(t *testing.T) {
+	t.Parallel()
+	s := &Store{}
+	prev := s.nextOrderTime()
+	for i := 0; i < 10000; i++ {
+		next := s.nextOrderTime()
+		if !next.After(prev) {
+			t.Fatalf("nextOrderTime did not increase: prev=%s, next=%s", prev, next)
+		}
+		prev = next
+	}
+}
+
 // TestFileStoreBig creates a fully populated Store and checks things work
 // Adding messages would make the structure bigger but should have no impact on the struct functions.
 // Commenting this out as it's very slow!


### PR DESCRIPTION
## Summary

Fixes #342.

Both `autopaho/queue/file` and `paho/store/file` order their entries by reading each file's `ModTime` back from the filesystem. As described in #342, some platforms/filesystems only update `ModTime` with a coarse resolution when a file is written (the kernel's "coarse current time" used for automatic write-time stamping), so files created in rapid succession can end up with an identical `ModTime` and then be retrieved/listed in the wrong order (falling back to directory read order rather than write order). This can cause queued/stored MQTT messages to be delivered or resent out of order.

## Fix

Instead of relying on the timestamp the OS applies automatically when a file is written, each `Queue`/`Store` now explicitly stamps the file's `ModTime` via `os.Chtimes`, using a value from its own in-memory, monotonically increasing clock (`nextOrderTime`). This guarantees a strictly increasing `ModTime` for files written by the same process, regardless of the underlying filesystem/OS timestamp granularity.

- No change to the public API (`Enqueue`/`Peek`/`Put`/`List`/... signatures are unchanged).
- No change to the on-disk filename format (`TestFileStoreNaming` still passes unmodified).
- Best-effort: if `os.Chtimes` fails, the entry has still been written safely, so the operation is not failed - ordering would just fall back to the pre-fix behaviour in that unlikely case.

## Tests

- `TestFileQueueOrderWithCoarseModTime` (autopaho/queue/file): enqueues 50 entries back-to-back with no delay and confirms Peek/Remove returns them in enqueue order.
- `TestNextOrderTimeMonotonic` (autopaho/queue/file): confirms `nextOrderTime` always returns strictly increasing values even in a tight loop, deterministically (no OS/filesystem dependency).
- `TestFileStoreListOrderWithCoarseModTime` (paho/store/file): Puts 100 packets back-to-back with no delay and confirms `List` preserves Put order.
- `TestFileStoreNextOrderTimeMonotonic` (paho/store/file): same monotonicity check for the store.

All pre-existing tests in both packages, and the full repo test suite (`go test ./...`), continue to pass. `go build ./...`, `go vet ./...`, and `gofmt -l` are clean on the changed files (the pre-existing `go vet` findings in `autopaho/persistence_test.go`, `paho/session/state/sendquota_test.go`, and `packets/properties_test.go` are unrelated to this change and present on `master` before it).

## AI assistance disclosure

This change (investigation, implementation, and tests) was developed with the assistance of Claude Code (Anthropic) and reviewed by me before submission, per this project's contribution norms.

## Eclipse Contributor Agreement

I understand this repository requires the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php) to be signed, associated with the commit author email, before this PR can be merged. I have not yet completed that step at the time of opening this PR - the commit includes a `Signed-off-by` trailer, but the ECA itself still needs to be signed via https://accounts.eclipse.org (Eclipse Foundation account required). Happy to follow up once that's done; flagging it here so reviewers have full context.