### PR TITLE
Address topic aliases issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,12 @@ these and cancel them all when the connection drops.
 ### Inbound topic aliases
 
 The client validates and resolves inbound topic aliases automatically, before session processing and message delivery.
-All routers and `OnPublishReceived` callbacks receive the full topic name, including callbacks added later using
-`Client.AddOnPublishReceived`. No topic alias callback is required.
+All routers and `OnPublishReceived` callbacks receive the full topic name. Library users should ignore `PUBLISH`
+`.Properties.TopicAlias` because `.Topic` will contain the full topic name.
 
-Alias mappings belong to the network connection and are reset on reconnection, even when the MQTT session is resumed.
-Retransmitted QoS 2 messages update alias mappings without being delivered to the application again if the session has
-already acknowledged them.
+The library resolves these automatically because alias mappings belong to the network connection and are reset on
+reconnection, even when the MQTT session is resumed. This means that a previously acknowledged QOS2 message (that will
+not be delivered to `OnPublishReceived`) can set an alias. Thus handling this outside of the library would be complicated.
 
 To allow the broker to use aliases, set a non-zero `TopicAliasMaximum` on the CONNECT packet. For example:
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,29 @@ Topic aliases are not part of the session state. This means that if messages usi
 connection drops and then sent when it comes up will not have the desired impact. Possible workaround would be to detect
 these and cancel them all when the connection drops.
 
+### Inbound topic aliases
+
+The client validates and resolves inbound topic aliases automatically, before session processing and message delivery.
+All routers and `OnPublishReceived` callbacks receive the full topic name, including callbacks added later using
+`Client.AddOnPublishReceived`. No topic alias callback is required.
+
+Alias mappings belong to the network connection and are reset on reconnection, even when the MQTT session is resumed.
+Retransmitted QoS 2 messages update alias mappings without being delivered to the application again if the session has
+already acknowledged them.
+
+To allow the broker to use aliases, set a non-zero `TopicAliasMaximum` on the CONNECT packet. For example:
+
+```go
+paho.Connect{
+    Properties: &paho.ConnectProperties{
+        TopicAliasMaximum: paho.Uint16(10),
+    },
+}
+```
+
+With AutoPaho, set this property through `ClientConfig.ConnectPacketBuilder`. An absent or zero maximum disables inbound
+aliases. Invalid aliases cause a DISCONNECT before the offending message is delivered or acknowledged.
+
 ### Multiple Servers
 
 If a Client may connect to more than one server, or the same server with different ClientIDs, then the user will need to 

--- a/paho/client.go
+++ b/paho/client.go
@@ -79,6 +79,8 @@ type (
 		// created via the AddOnPublishReceived function (Client holds a copy of the slice; OnPublishReceived will not change).
 		// When a `PUBLISH` is received, the callbacks will be called in order. If a callback processes the message,
 		// then it should return true. This boolean, and any errors, will be passed to subsequent handlers.
+		// Topic aliases are resolved before session processing and before any callbacks run.
+		// Set Connect.Properties.TopicAliasMaximum to allow the server to use inbound aliases.
 		OnPublishReceived []func(PublishReceived) (bool, error)
 
 		PacketTimeout time.Duration
@@ -484,6 +486,8 @@ func (c *Client) incoming(ctx context.Context) {
 	defer c.debug.Println("client stopping, incoming stopping")
 	defer close(c.publishPackets)
 
+	// Aliases belong to this network connection and are only accessed by incoming.
+	aliases := make(inboundTopicAliases)
 	for {
 		select {
 		case <-ctx.Done():
@@ -527,6 +531,19 @@ func (c *Client) incoming(ctx context.Context) {
 				}
 			case packets.PUBLISH:
 				pb := recv.Content.(*packets.Publish)
+				// Even a QoS 2 retransmission suppressed by the session may establish
+				// an alias. Resolve now, before filtering or acknowledging the packet.
+				if err := aliases.resolve(pb, c.clientProps.TopicAliasMaximum); err != nil {
+					// Disconnect waits for incoming to finish, so let it run separately.
+					go func() {
+						var reportedErr error = err
+						if sendErr := c.Disconnect(err.Disconnect()); sendErr != nil {
+							reportedErr = errors.Join(err, fmt.Errorf("sending topic alias disconnect: %w", sendErr))
+						}
+						c.config.OnClientError(reportedErr)
+					}()
+					return
+				}
 				if pb.QoS > 0 { // QOS1 or 2 need to be recorded in session state
 					if c.handleSessionPacketError(ctx, recv.Type, c.config.Session.PacketReceived(recv, c.publishPackets)) {
 						return

--- a/paho/inbound_alias_test.go
+++ b/paho/inbound_alias_test.go
@@ -31,8 +31,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// aliasTestConnection uses a real Client and session, with a broker that records
-// acknowledgments and DISCONNECT packets instead of completing QoS 2 exchanges.
+// aliasTestConnection connects a real Client and session to an in-memory broker.
+// max sets the advertised alias limit; resumed sets CONNACK's Session Present flag.
+// It returns the client, the broker connection used to send packets, and a channel recording client acknowledgments
+// and DISCONNECT packets. The broker leaves QoS 2 exchanges unfinished, so tests can resume them after reconnecting.
 func aliasTestConnection(t *testing.T, cfg ClientConfig, max *uint16, resumed bool) (*Client, net.Conn, <-chan *packets.ControlPacket) {
 	t.Helper()
 	clientConn, brokerConn := net.Pipe()
@@ -72,6 +74,8 @@ func aliasTestConnection(t *testing.T, cfg ClientConfig, max *uint16, resumed bo
 	return c, broker, received
 }
 
+// aliasTestSend sends a broker PUBLISH with a test payload and non-nil properties.
+// It fails the test if the packet cannot be written.
 func aliasTestSend(t *testing.T, broker net.Conn, p *packets.Publish) {
 	t.Helper()
 	// A nonempty payload also avoids a zero-byte net.Pipe write at packet end.
@@ -83,6 +87,8 @@ func aliasTestSend(t *testing.T, broker net.Conn, p *packets.Publish) {
 	require.NoError(t, err)
 }
 
+// aliasTestPacket waits for the next packet recorded by the broker and checks its type. A timeout or closed connection
+// fails the test instead of leaving it blocked.
 func aliasTestPacket(t *testing.T, ch <-chan *packets.ControlPacket, typ byte) *packets.ControlPacket {
 	t.Helper()
 	select {
@@ -96,6 +102,8 @@ func aliasTestPacket(t *testing.T, ch <-chan *packets.ControlPacket, typ byte) *
 	}
 }
 
+// aliasTestPublish waits for a message delivered to an application handler. It fails the test if no message arrives
+// before the timeout.
 func aliasTestPublish(t *testing.T, ch <-chan *Publish) *Publish {
 	t.Helper()
 	select {
@@ -107,6 +115,8 @@ func aliasTestPublish(t *testing.T, ch <-chan *Publish) *Publish {
 	}
 }
 
+// TestClientInboundAliasesAutomatic checks that configured callbacks, routers, and callbacks added later all receive
+// resolved topics without an alias handler.
 func TestClientInboundAliasesAutomatic(t *testing.T) {
 	for _, mode := range []string{"callbacks", "configured router", "default router", "router callback"} {
 		t.Run(mode, func(t *testing.T) {
@@ -137,6 +147,8 @@ func TestClientInboundAliasesAutomatic(t *testing.T) {
 	}
 }
 
+// TestClientInboundAliasesKeepQueuedTopics holds application callbacks while an alias is reassigned. Queued messages
+// must retain the topic that applied when each packet arrived, rather than picking up the alias's latest mapping.
 func TestClientInboundAliasesKeepQueuedTopics(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		delivered := make(chan *Publish, 4)
@@ -155,6 +167,9 @@ func TestClientInboundAliasesKeepQueuedTopics(t *testing.T) {
 	})
 }
 
+// TestClientInboundAliasOnQoS2Retransmission checks that a previously acknowledged message can register an alias after
+// reconnecting without being delivered twice. It covers automatic and manual acknowledgments and checks that a DUP
+// flag does not suppress a message the session has not previously acknowledged.
 func TestClientInboundAliasOnQoS2Retransmission(t *testing.T) {
 	for _, manual := range []bool{false, true} {
 		t.Run(fmt.Sprintf("manualAck=%t", manual), func(t *testing.T) {
@@ -207,6 +222,9 @@ func TestClientInboundAliasOnQoS2Retransmission(t *testing.T) {
 	}
 }
 
+// TestClientInboundAliasesRejectInvalid checks that invalid topics and aliases produce the expected DISCONNECT and
+// reported error before delivery or acknowledgment.
+// This must hold for every QoS, including retransmissions suppressed by the session.
 func TestClientInboundAliasesRejectInvalid(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -275,6 +293,8 @@ func TestClientInboundAliasesRejectInvalid(t *testing.T) {
 	}
 }
 
+// TestClientInboundAliasesAreConnectionScoped checks that reconnecting clears alias mappings even when both the MQTT
+// session and the router are reused.
 func TestClientInboundAliasesAreConnectionScoped(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		s := state.NewInMemory()
@@ -295,6 +315,8 @@ func TestClientInboundAliasesAreConnectionScoped(t *testing.T) {
 	})
 }
 
+// TestClientInboundAliasesWithSharedRouter checks that two active connections sharing a router can use the same alias
+// number for different topics.
 func TestClientInboundAliasesWithSharedRouter(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		delivered := make(chan *Publish, 4)

--- a/paho/inbound_alias_test.go
+++ b/paho/inbound_alias_test.go
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package paho
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/eclipse/paho.golang/packets"
+	"github.com/eclipse/paho.golang/paho/session/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// aliasTestConnection uses a real Client and session, with a broker that records
+// acknowledgments and DISCONNECT packets instead of completing QoS 2 exchanges.
+func aliasTestConnection(t *testing.T, cfg ClientConfig, max *uint16, resumed bool) (*Client, net.Conn, <-chan *packets.ControlPacket) {
+	t.Helper()
+	clientConn, brokerConn := net.Pipe()
+	cfg.Conn = packets.NewThreadSafeConn(clientConn)
+	broker := packets.NewThreadSafeConn(brokerConn)
+	received := make(chan *packets.ControlPacket, 16)
+	brokerDone := make(chan struct{})
+	go func() {
+		defer close(brokerDone)
+		defer close(received)
+		for {
+			p, err := packets.ReadPacket(broker)
+			if err != nil {
+				return
+			}
+			switch p.Type {
+			case packets.CONNECT:
+				_, err = (&packets.Connack{SessionPresent: resumed, Properties: &packets.Properties{}}).WriteTo(broker)
+			case packets.PINGREQ:
+				_, err = (&packets.Pingresp{}).WriteTo(broker)
+			default:
+				received <- p
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	c := NewClient(cfg)
+	_, err := c.Connect(context.Background(), &Connect{ClientID: "aliases", Properties: &ConnectProperties{TopicAliasMaximum: max, SessionExpiryInterval: Uint32(600)}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		c.close()
+		_ = broker.Close()
+		<-brokerDone
+	})
+	return c, broker, received
+}
+
+func aliasTestSend(t *testing.T, broker net.Conn, p *packets.Publish) {
+	t.Helper()
+	// A nonempty payload also avoids a zero-byte net.Pipe write at packet end.
+	p.Payload = []byte("reading")
+	if p.Properties == nil {
+		p.Properties = &packets.Properties{}
+	}
+	_, err := p.WriteTo(broker)
+	require.NoError(t, err)
+}
+
+func aliasTestPacket(t *testing.T, ch <-chan *packets.ControlPacket, typ byte) *packets.ControlPacket {
+	t.Helper()
+	select {
+	case p := <-ch:
+		require.NotNil(t, p, "connection closed before expected packet")
+		require.Equal(t, typ, p.Type)
+		return p
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for broker packet")
+		return nil
+	}
+}
+
+func aliasTestPublish(t *testing.T, ch <-chan *Publish) *Publish {
+	t.Helper()
+	select {
+	case p := <-ch:
+		return p
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for resolved PUBLISH")
+		return nil
+	}
+}
+
+func TestClientInboundAliasesAutomatic(t *testing.T) {
+	for _, mode := range []string{"callbacks", "configured router", "default router", "router callback"} {
+		t.Run(mode, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				delivered := make(chan *Publish, 4)
+				handle := func(pr PublishReceived) (bool, error) { delivered <- pr.Packet; return true, nil }
+				cfg := ClientConfig{}
+				switch mode {
+				case "callbacks":
+					cfg.OnPublishReceived = []func(PublishReceived) (bool, error){handle}
+				case "configured router":
+					cfg.Router = NewStandardRouterWithDefault(func(p *Publish) { delivered <- p })
+				case "router callback":
+					router := NewStandardRouterWithDefault(func(p *Publish) { delivered <- p })
+					cfg.OnPublishReceived = []func(PublishReceived) (bool, error){func(pr PublishReceived) (bool, error) { router.Route(pr.Packet.Packet()); return true, nil }}
+				}
+				c, broker, _ := aliasTestConnection(t, cfg, Uint16(1), false)
+				if mode == "default router" {
+					c.AddOnPublishReceived(handle)
+				}
+				aliasTestSend(t, broker, &packets.Publish{Topic: "sensors/temperature", Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+				aliasTestSend(t, broker, &packets.Publish{Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+				for range 2 {
+					assert.Equal(t, "sensors/temperature", aliasTestPublish(t, delivered).Topic)
+				}
+			})
+		})
+	}
+}
+
+func TestClientInboundAliasesKeepQueuedTopics(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		delivered := make(chan *Publish, 4)
+		release := make(chan struct{})
+		var once sync.Once
+		_, broker, _ := aliasTestConnection(t, ClientConfig{OnPublishReceived: []func(PublishReceived) (bool, error){func(pr PublishReceived) (bool, error) { <-release; delivered <- pr.Packet; return true, nil }}}, Uint16(1), false)
+		defer once.Do(func() { close(release) })
+		for _, topic := range []string{"old/topic", "", "new/topic", ""} {
+			aliasTestSend(t, broker, &packets.Publish{Topic: topic, Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+		}
+		synctest.Wait() // All four packets have been read while callbacks are held.
+		once.Do(func() { close(release) })
+		for _, want := range []string{"old/topic", "old/topic", "new/topic", "new/topic"} {
+			assert.Equal(t, want, aliasTestPublish(t, delivered).Topic)
+		}
+	})
+}
+
+func TestClientInboundAliasOnQoS2Retransmission(t *testing.T) {
+	for _, manual := range []bool{false, true} {
+		t.Run(fmt.Sprintf("manualAck=%t", manual), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				s := state.NewInMemory()
+				t.Cleanup(func() { require.NoError(t, s.Close()) })
+				delivered := make(chan *Publish, 4)
+				cfg := ClientConfig{
+					Session:                    s,
+					EnableManualAcknowledgment: manual,
+					OnPublishReceived: []func(PublishReceived) (bool, error){
+						func(pr PublishReceived) (bool, error) {
+							delivered <- pr.Packet
+							return true, nil
+						},
+					},
+				}
+				c1, b1, wire1 := aliasTestConnection(t, cfg, Uint16(2), false)
+				aliasTestSend(t, b1, &packets.Publish{QoS: 2, PacketID: 1, Topic: "sensors/temperature"})
+				first := aliasTestPublish(t, delivered)
+				if manual {
+					require.NoError(t, c1.Ack(first))
+				}
+				aliasTestPacket(t, wire1, packets.PUBREC)
+				c1.close() // Retain the PUBREC state, as if the broker never received it.
+
+				c2, b2, wire2 := aliasTestConnection(t, cfg, Uint16(2), true)
+				aliasTestSend(t, b2, &packets.Publish{QoS: 2, PacketID: 1, Duplicate: true, Topic: "sensors/temperature", Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+				aliasTestPacket(t, wire2, packets.PUBREC)
+				select {
+				case <-delivered:
+					t.Fatal("QoS 2 retransmission was delivered twice")
+				default:
+				}
+				aliasTestSend(t, b2, &packets.Publish{Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+				assert.Equal(t, "sensors/temperature", aliasTestPublish(t, delivered).Topic)
+
+				// A DUP flag alone does not prove prior delivery: an unknown packet
+				// ID must still reach the application.
+				aliasTestSend(t, b2, &packets.Publish{QoS: 2, PacketID: 2, Duplicate: true, Topic: "new/topic", Properties: &packets.Properties{TopicAlias: Uint16(2)}})
+				unseen := aliasTestPublish(t, delivered)
+				assert.Equal(t, "new/topic", unseen.Topic)
+				assert.True(t, unseen.Duplicate())
+				if manual {
+					require.NoError(t, c2.Ack(unseen))
+				}
+				aliasTestPacket(t, wire2, packets.PUBREC)
+			})
+		})
+	}
+}
+
+func TestClientInboundAliasesRejectInvalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		maximum *uint16
+		topic   string
+		alias   *uint16
+		reason  byte
+	}{
+		{"zero alias", Uint16(2), "topic", Uint16(0), packets.DisconnectTopicAliasInvalid},
+		{"above maximum", Uint16(2), "topic", Uint16(3), packets.DisconnectTopicAliasInvalid},
+		{"aliases disabled", Uint16(0), "topic", Uint16(1), packets.DisconnectTopicAliasInvalid},
+		{"maximum absent", nil, "topic", Uint16(1), packets.DisconnectTopicAliasInvalid},
+		{"unknown alias", Uint16(2), "", Uint16(1), packets.DisconnectProtocolError},
+		{"empty topic without alias", Uint16(2), "", nil, packets.DisconnectProtocolError},
+	}
+	for _, tt := range tests {
+		for _, delivery := range []string{"QoS0", "QoS1", "QoS2", "QoS2 duplicate"} {
+			t.Run(tt.name+"/"+delivery, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					s := state.NewInMemory()
+					t.Cleanup(func() { require.NoError(t, s.Close()) })
+					delivered := make(chan *Publish, 4)
+					errorsReceived := make(chan error, 1)
+					cfg := ClientConfig{Session: s, OnPublishReceived: []func(PublishReceived) (bool, error){func(pr PublishReceived) (bool, error) { delivered <- pr.Packet; return true, nil }}, OnClientError: func(err error) {
+						if _, ok := errors.AsType[*topicAliasError](err); ok {
+							errorsReceived <- err
+						}
+					}}
+					duplicate := delivery == "QoS2 duplicate"
+					if duplicate {
+						c1, b1, w1 := aliasTestConnection(t, cfg, tt.maximum, false)
+						aliasTestSend(t, b1, &packets.Publish{QoS: 2, PacketID: 1, Topic: "topic"})
+						aliasTestPublish(t, delivered)
+						aliasTestPacket(t, w1, packets.PUBREC)
+						c1.close()
+					}
+					c, broker, wire := aliasTestConnection(t, cfg, tt.maximum, duplicate)
+					qos := byte(0)
+					if delivery == "QoS1" {
+						qos = 1
+					} else if delivery != "QoS0" {
+						qos = 2
+					}
+					aliasTestSend(t, broker, &packets.Publish{QoS: qos, PacketID: 1, Duplicate: duplicate, Topic: tt.topic, Properties: &packets.Properties{TopicAlias: tt.alias}})
+					d := aliasTestPacket(t, wire, packets.DISCONNECT).Content.(*packets.Disconnect)
+					assert.Equal(t, tt.reason, d.ReasonCode)
+					select {
+					case <-c.Done():
+					case <-time.After(time.Second):
+						t.Fatal("invalid alias did not shut down client")
+					}
+					select {
+					case err := <-errorsReceived:
+						assert.ErrorContains(t, err, d.Properties.ReasonString)
+					case <-time.After(time.Second):
+						t.Fatal("alias error was not reported")
+					}
+					synctest.Wait()
+					assert.Empty(t, delivered, "invalid PUBLISH reached an application callback")
+					for p := range wire {
+						assert.NotContains(t, []byte{packets.PUBACK, packets.PUBREC}, p.Type, "invalid PUBLISH was acknowledged")
+					}
+				})
+			})
+		}
+	}
+}
+
+func TestClientInboundAliasesAreConnectionScoped(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s := state.NewInMemory()
+		t.Cleanup(func() { require.NoError(t, s.Close()) })
+		delivered := make(chan *Publish, 4)
+		// Reuse a router as AutoPaho does when creating clients for new connections.
+		router := NewStandardRouterWithDefault(func(p *Publish) { delivered <- p })
+		cfg := ClientConfig{Session: s, Router: router}
+		c1, b1, _ := aliasTestConnection(t, cfg, Uint16(1), false)
+		aliasTestSend(t, b1, &packets.Publish{Topic: "old/topic", Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+		assert.Equal(t, "old/topic", aliasTestPublish(t, delivered).Topic)
+		c1.close()
+		_, b2, w2 := aliasTestConnection(t, cfg, Uint16(1), true)
+		aliasTestSend(t, b2, &packets.Publish{Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+		d := aliasTestPacket(t, w2, packets.DISCONNECT).Content.(*packets.Disconnect)
+		assert.Equal(t, byte(packets.DisconnectProtocolError), d.ReasonCode)
+		assert.Empty(t, delivered)
+	})
+}
+
+func TestClientInboundAliasesWithSharedRouter(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		delivered := make(chan *Publish, 4)
+		router := NewStandardRouterWithDefault(func(p *Publish) { delivered <- p })
+		cfg := ClientConfig{Router: router}
+		_, b1, _ := aliasTestConnection(t, cfg, Uint16(1), false)
+		_, b2, _ := aliasTestConnection(t, cfg, Uint16(1), false)
+		for i, broker := range []net.Conn{b1, b2} {
+			topic := fmt.Sprintf("broker%d/topic", i)
+			aliasTestSend(t, broker, &packets.Publish{Topic: topic, Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+			assert.Equal(t, topic, aliasTestPublish(t, delivered).Topic)
+		}
+		for i, broker := range []net.Conn{b1, b2} {
+			aliasTestSend(t, broker, &packets.Publish{Properties: &packets.Properties{TopicAlias: Uint16(1)}})
+			assert.Equal(t, fmt.Sprintf("broker%d/topic", i), aliasTestPublish(t, delivered).Topic)
+		}
+	})
+}

--- a/paho/inbound_alias_test.go
+++ b/paho/inbound_alias_test.go
@@ -10,7 +10,13 @@
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.php.
  *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ * AI Disclosure: This file was largely generated using OpenAI Codex and
+ * refined through discussion and review. The AI-generated portions are
+ * made available under CC0-1.0, rather than the project licences above.
+ * Existing and human-authored portions retain their applicable licences.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR BSD-3-Clause) AND CC0-1.0
+ * Assisted-by: OpenAI Codex
  */
 
 package paho

--- a/paho/router.go
+++ b/paho/router.go
@@ -39,6 +39,7 @@ type MessageHandler func(*Publish)
 // MessageHandlers for
 // Route() takes a Publish message and determines which MessageHandlers
 // should be invoked
+// Note: Topic Aliases should be resolved before `Route` is called
 type Router interface {
 	RegisterHandler(string, MessageHandler)
 	UnregisterHandler(string)
@@ -52,7 +53,6 @@ type StandardRouter struct {
 	sync.RWMutex
 	defaultHandler MessageHandler
 	subscriptions  map[string][]MessageHandler
-	aliases        map[uint16]string
 	debug          log.Logger
 }
 
@@ -60,7 +60,6 @@ type StandardRouter struct {
 func NewStandardRouter() *StandardRouter {
 	return &StandardRouter{
 		subscriptions: make(map[string][]MessageHandler),
-		aliases:       make(map[uint16]string),
 		debug:         log.NOOPLogger{},
 	}
 }
@@ -103,25 +102,9 @@ func (r *StandardRouter) Route(pb *packets.Publish) {
 
 	m := PublishFromPacketPublish(pb)
 
-	var topic string
-	if pb.Properties.TopicAlias != nil {
-		r.debug.Println("message is using topic aliasing")
-		if pb.Topic != "" {
-			// Register new alias
-			r.debug.Printf("registering new topic alias '%d' for topic '%s'", *pb.Properties.TopicAlias, m.Topic)
-			r.aliases[*pb.Properties.TopicAlias] = pb.Topic
-		}
-		if t, ok := r.aliases[*pb.Properties.TopicAlias]; ok {
-			r.debug.Printf("aliased topic '%d' translates to '%s'", *pb.Properties.TopicAlias, m.Topic)
-			topic = t
-		}
-	} else {
-		topic = m.Topic
-	}
-
 	handlerCalled := false
 	for route, handlers := range r.subscriptions {
-		if match(route, topic) {
+		if match(route, m.Topic) {
 			r.debug.Println("found handler for:", route)
 			for _, handler := range handlers {
 				handler(m)

--- a/paho/router_test.go
+++ b/paho/router_test.go
@@ -17,6 +17,7 @@ package paho
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/eclipse/paho.golang/packets"
@@ -126,4 +127,21 @@ func Test_routeDefault(t *testing.T) {
 		t.Errorf("no router should have been called r1: %d, r2: %d", r1Count, r2Count)
 	}
 
+}
+
+// Issue #331 - Route had a data race around it's handling of topic aliases
+// Run with race detector
+func Test_routeAliasRace(t *testing.T) {
+	// Data race possible when an alias is set
+	r := NewStandardRouter()
+	alias := uint16(1)
+	var wg sync.WaitGroup
+
+	for range 2 {
+		wg.Go(func() {
+			r.Route(&packets.Publish{Topic: "test", Properties: &packets.Properties{TopicAlias: &alias}})
+			r.Route(&packets.Publish{Properties: &packets.Properties{TopicAlias: &alias}})
+		})
+	}
+	wg.Wait()
 }

--- a/paho/router_test.go
+++ b/paho/router_test.go
@@ -129,10 +129,10 @@ func Test_routeDefault(t *testing.T) {
 
 }
 
-// Issue #331 - Route had a data race around it's handling of topic aliases
-// Run with race detector
+// Test_routeAliasRace exercises concurrent calls to a shared router with aliases.
+// Run with -race to detect a recurrence of issue #331, where alias registrations
+// modified router state while holding only a read lock.
 func Test_routeAliasRace(t *testing.T) {
-	// Data race possible when an alias is set
 	r := NewStandardRouter()
 	alias := uint16(1)
 	var wg sync.WaitGroup

--- a/paho/topic_alias.go
+++ b/paho/topic_alias.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package paho
+
+import (
+	"fmt"
+
+	"github.com/eclipse/paho.golang/packets"
+)
+
+// inboundTopicAliases is owned by incoming for the lifetime of one connection.
+// Resolve each packet before queuing it so later alias reassignments cannot
+// change the topics of packets still waiting for application callbacks.
+type inboundTopicAliases map[uint16]string
+
+func (a inboundTopicAliases) resolve(p *packets.Publish, maximum uint16) *topicAliasError {
+	if p.Properties == nil || p.Properties.TopicAlias == nil {
+		if p.Topic == "" {
+			return &topicAliasError{packets.DisconnectProtocolError, "topic name must not be empty when topic alias is absent"}
+		}
+		return nil
+	}
+	alias := *p.Properties.TopicAlias
+	if alias == 0 { // MQTT-3.3.2-8
+		return &topicAliasError{packets.DisconnectTopicAliasInvalid, "topic alias must be greater than zero"}
+	}
+	if alias > maximum { // MQTT-3.3.2-11
+		return &topicAliasError{packets.DisconnectTopicAliasInvalid, fmt.Sprintf("topic alias %d exceeds maximum %d", alias, maximum)}
+	}
+	if p.Topic != "" {
+		a[alias] = p.Topic
+		return nil
+	}
+	if topic, ok := a[alias]; ok {
+		p.Topic = topic
+		return nil
+	}
+	// MQTT 5.0 section 3.3.4: an unknown alias without a topic is a Protocol Error.
+	return &topicAliasError{packets.DisconnectProtocolError, fmt.Sprintf("topic alias %d not found", alias)}
+}
+
+type topicAliasError struct {
+	reasonCode byte
+	message    string
+}
+
+func (e *topicAliasError) Error() string { return e.message }
+
+func (e *topicAliasError) Disconnect() *Disconnect {
+	return &Disconnect{
+		ReasonCode: e.reasonCode,
+		Properties: &DisconnectProperties{ReasonString: e.message},
+	}
+}

--- a/paho/topic_alias.go
+++ b/paho/topic_alias.go
@@ -22,10 +22,13 @@ import (
 )
 
 // inboundTopicAliases is owned by incoming for the lifetime of one connection.
-// Resolve each packet before queuing it so later alias reassignments cannot
-// change the topics of packets still waiting for application callbacks.
+// Resolve each packet before queuing it so later alias reassignments cannot change the topics of packets still waiting
+// for application callbacks.
 type inboundTopicAliases map[uint16]string
 
+// resolve validates the topic and alias against the maximum advertised in CONNECT.
+// It records alias registrations or fills in p.Topic from an existing mapping.
+// Invalid packets return an error containing the required DISCONNECT reason.
 func (a inboundTopicAliases) resolve(p *packets.Publish, maximum uint16) *topicAliasError {
 	if p.Properties == nil || p.Properties.TopicAlias == nil {
 		if p.Topic == "" {
@@ -52,13 +55,17 @@ func (a inboundTopicAliases) resolve(p *packets.Publish, maximum uint16) *topicA
 	return &topicAliasError{packets.DisconnectProtocolError, fmt.Sprintf("topic alias %d not found", alias)}
 }
 
+// topicAliasError describes an invalid inbound topic or alias and its MQTT reason code.
 type topicAliasError struct {
 	reasonCode byte
 	message    string
 }
 
+// Error returns the explanation of the invalid topic or alias.
 func (e *topicAliasError) Error() string { return e.message }
 
+// Disconnect builds the packet used to report the error to the broker.
+// It does not send the packet or close the connection.
 func (e *topicAliasError) Disconnect() *Disconnect {
 	return &Disconnect{
 		ReasonCode: e.reasonCode,

--- a/paho/topic_alias.go
+++ b/paho/topic_alias.go
@@ -10,7 +10,12 @@
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.php.
  *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ * AI Disclosure: This file was largely generated using OpenAI Codex and refined through discussion and review.
+ * The AI-generated portions are made available under CC0-1.0, rather than the project licences above.
+ * Existing and human-authored portions retain their applicable licences.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR BSD-3-Clause) AND CC0-1.0
+ * Assisted-by: OpenAI Codex
  */
 
 package paho


### PR DESCRIPTION
Replaces PRs #335 and #346 

The way inbound aliases were handled was problematic:
* Data race in `paho/router` (issue #331 
* `StandardRouter` was using the alias when resolving the route, but not passing it to the handler (so `.Topic` might be an empty string).

Having looked at a few approaches I determined that this is best handled within `Client` due to the complexities around handling QOS2 retransmissions (which may set an alias, but not be passed to the router).

AI disclosure: OpenAI Codex substantially assisted with the design, implementation, regression tests, comments and README changes in this PR. The inbound topic-alias implementation and new tests were largely AI-generated, then refined through discussion and review. Existing Paho code and the MQTT specification informed the implementation.


I have reviewed the resulting changes and take responsibility for this contribution.

closes #331 
closes #332