### PR TITLE
Preserve CONNACK details in connection errors

### DIFF
--- a/autopaho/error.go
+++ b/autopaho/error.go
@@ -89,9 +89,10 @@ func (d *DisconnectError) Error() string {
 
 // ConnackError will be passed when the server denies connection in CONNACK packet
 type ConnackError struct {
-	ReasonCode byte   // CONNACK reason code
-	Reason     string // CONNACK Reason string from properties
-	Err        error  // underlying error
+	ReasonCode byte          // CONNACK reason code
+	Reason     string        // CONNACK Reason string from properties
+	Err        error         // underlying error
+	Connack    *paho.Connack // complete CONNACK received from the server, including its properties
 }
 
 // NewConnackError returns a new ConnackError
@@ -104,6 +105,7 @@ func NewConnackError(err error, connack *paho.Connack) *ConnackError {
 		ReasonCode: connack.ReasonCode,
 		Reason:     reason,
 		Err:        err,
+		Connack:    connack,
 	}
 }
 

--- a/autopaho/error_test.go
+++ b/autopaho/error_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ *  and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package autopaho
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/eclipse/paho.golang/paho"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConnackError(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		properties *paho.ConnackProperties
+	}{
+		{name: "without properties"},
+		{
+			name: "redirect without reason string",
+			properties: &paho.ConnackProperties{
+				ServerReference: "other.example:1883",
+			},
+		},
+		{
+			name: "redirect with reason string and user properties",
+			properties: &paho.ConnackProperties{
+				ServerReference: "other.example:1883",
+				ReasonString:    "use another server",
+				User:            paho.UserProperties{{Key: "detail", Value: "redirect"}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ca := &paho.Connack{ReasonCode: 0x9C, Properties: tc.properties}
+			underlying := errors.New("connection refused")
+			err := fmt.Errorf("connection attempt: %w", NewConnackError(underlying, ca))
+
+			var connackErr *ConnackError
+			require.ErrorAs(t, err, &connackErr)
+			require.Same(t, ca, connackErr.Connack)
+			assert.ErrorIs(t, err, underlying)
+			assert.Equal(t, underlying, connackErr.Err)
+			assert.Equal(t, ca.ReasonCode, connackErr.ReasonCode)
+			if tc.properties == nil {
+				assert.Empty(t, connackErr.Reason)
+			} else {
+				assert.Equal(t, tc.properties.ReasonString, connackErr.Reason)
+				assert.Equal(t, "other.example:1883", connackErr.Connack.Properties.ServerReference)
+				assert.Equal(t, tc.properties.User, connackErr.Connack.Properties.User)
+			}
+			assert.EqualError(t, connackErr, "server denied connect (reason: 156): connection refused")
+		})
+	}
+}

--- a/paho/client.go
+++ b/paho/client.go
@@ -315,7 +315,10 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 			reason = ca.Properties.ReasonString
 		}
 		cleanup()
-		return ca, fmt.Errorf("failed to connect to server: %s", reason)
+		if reason != "" {
+			return ca, fmt.Errorf("failed to connect to server (reason code: 0x%02X): %s", ca.ReasonCode, reason)
+		}
+		return ca, fmt.Errorf("failed to connect to server (reason code: 0x%02X)", ca.ReasonCode)
 	}
 
 	if err := c.config.Session.ConAckReceived(c.config.Conn, ccp, caPacket); err != nil {

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -109,6 +109,64 @@ func TestClientConnect(t *testing.T) {
 	assert.Equal(t, uint8(0), ca.ReasonCode)
 }
 
+func TestClientConnectRejected(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		reasonCode byte
+		properties *packets.Properties
+		wantError  string
+	}{
+		{
+			name:       "without properties",
+			reasonCode: 0x87,
+			wantError:  "failed to connect to server (reason code: 0x87)",
+		},
+		{
+			name:       "redirect without reason string",
+			reasonCode: 0x9C,
+			properties: &packets.Properties{ServerReference: "other.example:1883"},
+			wantError:  "failed to connect to server (reason code: 0x9C)",
+		},
+		{
+			name:       "redirect with reason string",
+			reasonCode: 0x9D,
+			properties: &packets.Properties{
+				ServerReference: "other.example:1883",
+				ReasonString:    "server moved",
+			},
+			wantError: "failed to connect to server (reason code: 0x9D): server moved",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := basictestserver.New(paholog.NewTestLogger(t, "TestServer:"))
+			ts.SetResponse(packets.CONNACK, &packets.Connack{
+				ReasonCode: tc.reasonCode,
+				Properties: tc.properties,
+			})
+			go ts.Run()
+			defer ts.Stop()
+
+			c := NewClient(ClientConfig{Conn: ts.ClientConn()})
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			ca, err := c.Connect(ctx, &Connect{ClientID: "testClient", CleanStart: true})
+			require.EqualError(t, err, tc.wantError)
+			require.NotNil(t, ca)
+			assert.Equal(t, tc.reasonCode, ca.ReasonCode)
+			if tc.properties != nil {
+				require.NotNil(t, ca.Properties)
+				assert.Equal(t, tc.properties.ServerReference, ca.Properties.ServerReference)
+				assert.Equal(t, tc.properties.ReasonString, ca.Properties.ReasonString)
+			}
+			select {
+			case <-c.Done():
+			default:
+				t.Error("rejected connection should be closed")
+			}
+		})
+	}
+}
+
 func TestClientSubscribe(t *testing.T) {
 	clientLogger := paholog.NewTestLogger(t, "ClientSubscribe:")
 	ts := basictestserver.New(paholog.NewTestLogger(t, "TestServer:"))


### PR DESCRIPTION
Add the full CONNACK to autopaho.ConnackError so callers can access ServerReference and other properties. Retain existing fields and error wrapping, and always include the reason code in connection failure text.

Add regression tests for retained properties and optional reason strings.

Fixes #353

AI assistance: OpenAI Codex assisted with implementation and tests